### PR TITLE
Add SRPM functionality and fix few things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,147 @@
-*.pyc
-.vscode
-.pytest_cache
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+# build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
 htmlcov/
-module_build.egg*/
+.tox/
+.nox/
 .coverage
-__pycache__
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# Support for Project snippet scope
+.vscode/*.code-snippets
+
+# Ignore code-workspaces
+*.code-workspace
+
+# End of https://www.toptal.com/developers/gitignore/api/python,visualstudiocode

--- a/README.md
+++ b/README.md
@@ -145,3 +145,11 @@ Sometimes a build of a component can consume a lot of disk space. By default `mo
 ```
 $ module-build -f flatpak-runtime.yaml -c /etc/mock/fedora-35-x86_64.cfg --rootdir=/path/to/custom/dir/ ./workdir
 ```
+
+## Building a module stream components from SRPMs
+This option allows to build all components directly from SRPM instead of utilizing SCM. You acn turn in on by specifiing directory path with source RPMs in `--srpm-dir`.
+<br />
+<br />
+```
+$ module-build -f flatpak-runtime.yaml -c /etc/mock/fedora-35-x86_64.cfg --srpm-dir /path/to/srpms  ./workdir
+```

--- a/module_build/builders/mock_builder.py
+++ b/module_build/builders/mock_builder.py
@@ -239,8 +239,14 @@ class MockBuilder:
         :type module_stream: :class:`module_build.stream.ModuleBuild` object
         """
         mock_path, mock_filename = self.mock_cfg_path.rsplit("/", 1)
-        mock_cfg = mockbuild.config.load_config(mock_path, self.mock_cfg_path, None,
-                                                module_stream.version, mock_path)
+
+        # Support for mock2 and mock3
+        # mockbuild is missing __version__ attribute so we are handling Exception
+        try:
+            mock_cfg = mockbuild.config.load_config(mock_path, self.mock_cfg_path, None,
+                                                    module_stream.version, mock_path)
+        except TypeError:
+            mock_cfg = mockbuild.config.load_config(mock_path, self.mock_cfg_path, None)
 
         dist = None
         if "dist" in mock_cfg:

--- a/module_build/builders/mock_builder.py
+++ b/module_build/builders/mock_builder.py
@@ -1,26 +1,36 @@
 import copy
 import os
 import shutil
+import tempfile
 import subprocess
 from collections import OrderedDict
+from pathlib import Path
+import libarchive
 
 import mockbuild.config
+from module_build.constants import SPEC_EXTENSION, SRPM_EXTENSIONS, SRPM_MAPPING_FILENAME
 
 from module_build.log import logger
 from module_build.metadata import (generate_and_populate_output_mmd, mmd_to_str,
                                    generate_module_stream_version)
+from module_build.mock.info import MockBuildInfo
+from module_build.mock.config import MockConfig
 from module_build.modulemd import Modulemd
 
 
 class MockBuilder:
     # TODO enable building only specific contexts
     # TODO enable multiprocess queues for component building.
-    def __init__(self, mock_cfg_path, workdir, external_repos, rootdir):
+    def __init__(self, mock_cfg_path, workdir, external_repos, rootdir, srpm_dir):
         self.states = ["init", "building", "failed", "finished"]
         self.workdir = workdir
         self.mock_cfg_path = mock_cfg_path
         self.external_repos = external_repos
         self.rootdir = rootdir
+
+        self.mock_info = MockBuildInfo()
+        if srpm_dir:
+            self._map_srpm_files(srpm_dir)
 
     def build(self, module_stream, resume, context_to_build=None):
         # first we must process the metadata provided by the module stream
@@ -108,6 +118,14 @@ class MockBuilder:
                         logger.info(msg)
                         continue
 
+                    if self.mock_info.srpms_enabled():
+                        if srpm_path := self.mock_info.get_srpm_path(component["name"], component["ref"]):
+                            logger.info(f"Found SRPM for: {component['name']}")
+                        else:
+                            raise Exception(f"Missing SRPM for {component['name']}")
+                    else:
+                        srpm_path = ""
+
                     msg = "Building component {index} out of {all}...".format(
                         index=index + 1,
                         all=len(batch["components"]))
@@ -127,18 +145,18 @@ class MockBuilder:
                     )
                     logger.info(msg)
                     # we prepare a mock config for the mock buildroot.
-                    mock_cfg_str = self.generate_and_process_mock_cfg(component, context_name,
-                                                                      position)
+                    mock_cfg = self.generate_and_process_mock_cfg(component, context_name,
+                                                                  position)
 
                     msg = "Initializing mock buildroot for component '{name}'...".format(
                         name=component["name"]
                     )
                     logger.info(msg)
 
-                    buildroot = MockBuildroot(component, mock_cfg_str, batch["dir"], position,
+                    buildroot = MockBuildroot(component, mock_cfg, batch["dir"], position,
                                               build_context["modularity_label"],
                                               build_context["rpm_suffix"],
-                                              batch_repo, self.external_repos, self.rootdir)
+                                              batch_repo, self.external_repos, self.rootdir, srpm_path)
 
                     buildroot.run()
 
@@ -156,6 +174,47 @@ class MockBuilder:
 
             build_context["status"]["state"] = self.states[3]
             self.finalize_build_context(context_name)
+
+    def _map_srpm_files(self, srpm_dir):
+        logger.info(f"Mapping SRPMs in directory: {srpm_dir}")
+
+        srpm_dir = Path(srpm_dir)
+
+        for file in srpm_dir.iterdir():
+            if not set(SRPM_EXTENSIONS).issubset(set(file.suffixes)):
+                continue
+
+            logger.info(f"SRPM: Mapping component for '{file.name}' file")
+
+            with libarchive.file_reader(str(file.resolve())) as archive:
+                for entry in archive:
+                    # check for spec file
+                    if not all((entry.isfile, entry.pathname.endswith(SPEC_EXTENSION))):
+                        continue
+
+                    logger.info(
+                        f"SRPM: Located .spec file: '{entry.pathname}'")
+
+                    # read content of spec file and look for "Name:"
+                    with tempfile.NamedTemporaryFile() as tmp:
+                        for block in entry.get_blocks():
+                            tmp.write(block)
+
+                        # Reset fd
+                        tmp.flush()
+                        tmp.seek(0)
+
+                        for line in tmp:
+                            # we are still in bytes
+                            line_str = line.decode("utf-8")
+
+                            if line_str.startswith("Name:"):
+                                component_name = line_str.split(":", 1)[1].strip()
+                                logger.info(
+                                    f"SRPM: Found SRPM: '{file.name}' for component: '{component_name}'")
+                                self.mock_info.add_srpm(component_name, srpm_dir / file.name)
+                                break
+                    break
 
     def final_report(self):
         pass
@@ -369,16 +428,11 @@ class MockBuilder:
         return batches_dir_path
 
     def generate_and_process_mock_cfg(self, component, context_name, batch_num):
-        # TODO consider to remove from this class and make a standalone function
-        mock_cfg_str = ""
-        mock_cfg_str += "config_opts['scm'] = True\n"
-        mock_cfg_str += "config_opts['scm_opts']['method'] = 'distgit'\n"
-        mock_cfg_str += "config_opts['scm_opts']['package'] = '{component_name}'\n".format(
-            component_name=component["name"]
-        )
-        mock_cfg_str += "config_opts['scm_opts']['branch'] = '{component_ref}'\n".format(
-            component_ref=component["ref"]
-        )
+        mock_config = MockConfig(self.mock_cfg_path)
+
+        # building modules from SRPM don't require MBS plugin
+        if not self.mock_info.srpms_enabled():
+            mock_config.enable_mbs("distgit", component["name"], component["ref"])
 
         # we need to tell mock which modular build dependencies need to be enabled
         context = self.build_contexts[context_name]
@@ -390,29 +444,16 @@ class MockBuilder:
         # grouped into batch_0 by default and the `modular_batch_deps` will be an empty list.
         modular_batch_deps = context["build_batches"][batch_num]["modular_batch_deps"]
         modules_to_enable = modular_deps + modular_batch_deps
-        mock_cfg_str += "# we enable necesary build module dependencies.\n"
-        mock_cfg_str += "config_opts['module_enable'] = {modules}\n".format(
-            modules=modules_to_enable)
 
         buildroot_profiles = context["buildroot_profiles"]
         srpm_buildroot_profiles = context["srpm_buildroot_profiles"]
         profiles_to_install = buildroot_profiles + srpm_buildroot_profiles
 
-        mock_cfg_str += "config_opts['module_install'] = {profiles}\n".format(
-            profiles=profiles_to_install)
+        mock_config.enable_modules(modules_to_enable)
+        mock_config.enable_modules(profiles_to_install, True)
+        mock_config.add_macros(context["rpm_macros"])
 
-        mock_cfg_str += "# we set the necessary macros provided by the `build_opts` option.\n"
-        for m in context["rpm_macros"]:
-            if m:
-                macro, value = m.split(" ")
-                mock_cfg_str += "config_opts['macros']['{macro}'] = {value}\n".format(
-                    macro=macro,
-                    value=value,
-                )
-
-        mock_cfg_str += "include('{mock_cfg_path}')\n".format(mock_cfg_path=self.mock_cfg_path)
-
-        return mock_cfg_str
+        return mock_config
 
     def finalize_batch(self, position, context_name):
         msg = "Batch number {num} finished building all its components.".format(num=position)
@@ -926,21 +967,21 @@ class MockBuilder:
 
 
 class MockBuildroot:
-    def __init__(self, component, mock_cfg_str, batch_dir_path, batch_num, modularity_label,
-                 rpm_suffix, batch_repo, external_repos, rootdir):
+    def __init__(self, component, mock_cfg, batch_dir_path, batch_num, modularity_label,
+                 rpm_suffix, batch_repo, external_repos, rootdir, srpm_path):
 
         self.finished = False
         self.component = component
-        self.mock_cfg_str = mock_cfg_str
         self.batch_dir_path = batch_dir_path
         self.batch_num = batch_num
         self.modularity_label = modularity_label
         self.rpm_suffix = rpm_suffix
         self.result_dir_path = self._create_buildroot_result_dir()
-        self.mock_cfg_path = self._create_mock_cfg_file()
+        self.mock_cfg_path = mock_cfg.write_config(self.result_dir_path, self.component["name"])
         self.batch_repo = batch_repo
         self.external_repos = external_repos
         self.rootdir = rootdir
+        self.srpm_path = srpm_path
 
     def run(self):
         mock_cmd = ["mock", "-v", "-r", self.mock_cfg_path,
@@ -957,6 +998,9 @@ class MockBuildroot:
 
         if self.rootdir:
             mock_cmd.append("--rootdir={rootdir}".format(rootdir=self.rootdir))
+
+        if self.srpm_path:
+            mock_cmd.append(self.srpm_path)
 
         msg = "Running mock buildroot for component '{name}' with command:\n{cmd}".format(
             name=self.component["name"],
@@ -1023,20 +1067,3 @@ class MockBuildroot:
         logger.info(msg)
 
         return result_dir_path
-
-    def _create_mock_cfg_file(self):
-        mock_cfg_file_path = "{result_dir_path}/{component_name}_mock.cfg".format(
-            result_dir_path=self.result_dir_path,
-            component_name=self.component["name"]
-        )
-
-        with open(mock_cfg_file_path, "w") as f:
-            f.write(self.mock_cfg_str)
-
-        msg = "Mock config for '{name}' component written to: {path}".format(
-            name=self.component["name"],
-            path=mock_cfg_file_path,
-        )
-        logger.info(msg)
-
-        return mock_cfg_file_path

--- a/module_build/cli.py
+++ b/module_build/cli.py
@@ -13,6 +13,7 @@ from module_build.stream import ModuleStream
 
 class FullPathAction(argparse.Action):
     """ A custom argparse action which converts all relative paths to absolute. """
+
     def __call__(self, parser, args, values, option_string=None):
         full_path = self._get_full_path(values)
         # `add_repo` should be an `append` action
@@ -74,7 +75,12 @@ def get_arg_parser():
                               " also required when using the resume feature. You can specify which "
                               "module stream version you want to resume."))
 
-    parser.add_argument("-x", "--module-context", type=str,
+    parser.add_argument("-m", "--srpm-dir", type=str,
+                        help=("Path to directory with SRPMs. When set, all module components will be"
+                              " build from given sources."),
+                        action=FullPathAction)
+
+    parser.add_argument("-g", "--module-context", type=str,
                         help=("When set it will only build the selected context from the modules"
                               " stream."))
     # TODO verbose is not implemented
@@ -133,7 +139,7 @@ def main():
     if not mmd:
         raise Exception("no input")
 
-# PHASE2: init the builder
+        # PHASE2: init the builder
     if args.module_context:
         log_msg = "Starting to build the '{name}:{stream}:{context}' of the module stream.".format(
             name=module_stream.name,
@@ -149,7 +155,8 @@ def main():
     logger.info(log_msg)
 
     # TODO add exceptions
-    mock_builder = MockBuilder(args.mock_cfg, args.workdir, args.add_repo, args.rootdir)
+    mock_builder = MockBuilder(args.mock_cfg, args.workdir,
+                               args.add_repo, args.rootdir, args.srpm_dir)
 
 # PHASE3: try to build the module stream
     try:

--- a/module_build/constants.py
+++ b/module_build/constants.py
@@ -1,0 +1,10 @@
+# Config
+KEY_MODULE_INSTALL = "config_opts['module_install']"
+KEY_MODULE_ENABLE = "config_opts['module_enable']"
+
+# Mock
+SRPM_EXTENSIONS = [".rpm", ".src"]
+SPEC_EXTENSION = ".spec"
+
+SRPM_MAPPING_FILENAME = "srpm_mapping"
+ROOT_BATCH_FOLDER = "build_batches"

--- a/module_build/mock/config.py
+++ b/module_build/mock/config.py
@@ -1,0 +1,48 @@
+from module_build.constants import KEY_MODULE_ENABLE, KEY_MODULE_INSTALL
+from module_build.log import logger
+
+
+class MockConfig:
+    def __init__(self, mock_cfg_path):
+        self.content = {}
+        self.base_mock_cfg_path = mock_cfg_path
+
+    def enable_modules(self, modules, to_install=False):
+        key = KEY_MODULE_INSTALL if to_install else KEY_MODULE_ENABLE
+
+        if key in self.content:
+            self.content[key].append(modules)
+        else:
+            self.content[key] = modules
+
+    def enable_mbs(self, method, package, branch):
+        self.content = {
+            "config_opts['scm']": "True",
+            "config_opts['scm_opts']['method']": f"'{method}'",
+            "config_opts['scm_opts']['package']": f"'{package}'",
+            "config_opts['scm_opts']['branch']": f"'{branch}'",
+        }
+
+    def disable_mbs(self):
+        for k in list(self.content.keys()):
+            if k.startswith("config_opts['scm'"):
+                del self.content[k]
+
+    def add_macros(self, macros):
+        for m in macros:
+            if m:
+                macro, value = m.split(" ")
+                self.content[f"config_opts['macros']['{macro}']"] = {value}
+
+    def write_config(self, result_dir, component_name):
+        path = f"{result_dir}/{component_name}_mock.cfg"
+
+        with open(path, "w") as f:
+            for key, value in self.content.items():
+                f.write(f"{key} = {value}\n")
+
+            f.write(f"include('{self.base_mock_cfg_path}')")
+
+        logger.info("Mock config for '{component_name}' component written to: {path}")
+
+        return path

--- a/module_build/mock/info.py
+++ b/module_build/mock/info.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+
+
+class MockBuildInfo():
+    def __init__(self):
+        self.srpms = []
+
+    def _if_srpm_present(self, name):
+        return [srpm for srpm in self.srpms if srpm.name == name]
+
+    def add_srpm(self, name, path):
+        """Add MockBuildInfoSRPM object to current instance.
+
+        Args:
+            name (str): Name of module.
+            path (str, Path): Path to the srpm.
+        """
+        if srpms := self._if_srpm_present(name):
+            srpms[0].add_path(path)
+        else:
+            self.srpms.append(MockBuildInfoSRPM(name, path))
+
+    def get_srpm_path(self, name, match=""):
+        """Wrapped for getting path from MockBuildInfoSRPM based on module name.
+
+        Args:
+            name (str): Module name.
+            match (str, optional): Module ref. Defaults to "".
+
+        Returns:
+            str: Relative path to srpm.
+        """
+        for srpm in self.srpms:
+            if srpm.name == name:
+                return srpm.get_path(match)
+
+        return None
+
+    def get_srpm_count(self):
+        """Returns number of MockBuildInfoSRPM stored in object.
+
+        Returns:
+            int: Number of srpms objects.
+        """
+        return len(self.srpms)
+
+    def srpms_enabled(self):
+        """Check if srpm mode is enabled based on number MockBuildInfoSRPM
+        objects stored in class.
+
+        Returns:
+            bool: Check if srpms are enabled
+        """
+        return self.srpms != []
+
+
+class MockBuildInfoSRPM():
+    """
+    Object which stores single SRPM information.
+    Part of MockBuildInfo.
+    """
+
+    def __init__(self, name, path):
+        self.name = name
+        self.paths = [self._make_path_obj(path)]
+
+    def _make_path_obj(self, path):
+        """Helper method for parsing srpm path.
+
+        Args:
+            path (Path, str): Path to srpm
+
+        Raises:
+            Exception: Default/
+
+        Returns:
+            Path: Path object to srpm.
+        """
+        if isinstance(path, Path):
+            return path
+        elif isinstance(path, str):
+            return Path(path)
+        else:
+            raise Exception("Wrong path object")
+
+    def add_path(self, path):
+        """Method for adding additional srpm paths for modules.
+
+        Args:
+            path (Path, str): Path for SRPM.
+        """
+        path = self._make_path_obj(path)
+        self.paths.append(path)
+
+    def get_path(self, match=""):
+        """Method that returns path to srpm.
+
+        Args:
+            match (str, optional): String that should be part of src name. Defaults to "".
+
+        Returns:
+            str: Relative srpm path
+        """
+        # By default return first object
+        if len(self.paths) == 1:
+            return str(self.paths[0].resolve())
+
+        # In case of multiple SRPM with the same name, try to match one using 'ref'
+        for path in self.paths:
+            if match in path.name:
+                return str(path.resolve())
+
+        # Should never happend but just in case
+        return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PyGObject
+libarchive-c

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -73,6 +73,15 @@ def fake_get_artifacts(self, artifacts):
     return artifacts_nevra
 
 
+def fake_call_createrepo_c_on_dir(self, dir):
+    """Helper function to simulate createrepo_c command execution
+    """
+    if os.path.isdir(dir):
+        repo_dir = dir + "/repodata"
+        if not os.path.exists(repo_dir):
+            os.mkdir(repo_dir)
+
+
 def assert_modular_dependencies(modular_deps, expected_modular_deps):
     """ A helper method for comparing result and expected modular dependecies of a module stream """
 

--- a/tests/builders/test_resume.py
+++ b/tests/builders/test_resume.py
@@ -6,10 +6,11 @@ import pytest
 
 from module_build.builders.mock_builder import MockBuilder
 from module_build.stream import ModuleStream
-from tests import (fake_buildroot_run, fake_get_artifacts, get_full_data_path,
+from tests import (fake_buildroot_run, fake_call_createrepo_c_on_dir, fake_get_artifacts, get_full_data_path,
                    mock_mmdv3_and_version)
 
 
+@patch("module_build.builders.mock_builder.MockBuilder.call_createrepo_c_on_dir", new=fake_call_createrepo_c_on_dir)
 @patch("module_build.builders.mock_builder.MockBuilder.get_artifacts_nevra", new=fake_get_artifacts)
 @patch("module_build.builders.mock_builder.mockbuild.config.load_config",
        return_value={"target_arch": "x86_64", "dist": "fc35"})
@@ -17,10 +18,11 @@ def test_resume_module_build_failed_first_component(mock_config, tmpdir):
     """ We test to resume the module build from the first failed component """
     cwd = tmpdir.mkdir("workdir").strpath
     rootdir = None
+    srpm_dir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -61,7 +63,7 @@ def test_resume_module_build_failed_first_component(mock_config, tmpdir):
     assert "perl-0:1.0-1.module_fc35+f26devel.x86_64.rpm" not in perl_comp_dir
 
     # we run the build again on the same working directory with the resume option on
-    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir)
+    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
     with patch("module_build.builders.mock_builder.MockBuildroot.run",
                new=fake_buildroot_run):
         builder_resumed.build(module_stream, resume=True)
@@ -86,6 +88,7 @@ def test_resume_module_build_failed_first_component(mock_config, tmpdir):
     assert "perl-0:1.0-1.module_fc35+f26devel.x86_64.rpm" in perl_comp_dir
 
 
+@patch("module_build.builders.mock_builder.MockBuilder.call_createrepo_c_on_dir", new=fake_call_createrepo_c_on_dir)
 @patch("module_build.builders.mock_builder.MockBuilder.get_artifacts_nevra", new=fake_get_artifacts)
 @patch("module_build.builders.mock_builder.mockbuild.config.load_config",
        return_value={"target_arch": "x86_64", "dist": "fc35"})
@@ -93,10 +96,11 @@ def test_resume_module_build_failed_not_first_component(mock_config, tmpdir):
     """ We test to resume the module build from a failed component in the 4th batch """
     cwd = tmpdir.mkdir("workdir").strpath
     rootdir = None
+    srpm_dir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -141,7 +145,7 @@ def test_resume_module_build_failed_not_first_component(mock_config, tmpdir):
     assert "perl-Digest-0:1.0-1.module_fc35+f26devel.x86_64.rpm" not in perl_digest_comp_dir
 
     # we run the build again on the same working directory with the resume option on
-    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir)
+    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
     with patch("module_build.builders.mock_builder.MockBuildroot.run",
                new=fake_buildroot_run):
         builder_resumed.build(module_stream, resume=True)
@@ -166,6 +170,7 @@ def test_resume_module_build_failed_not_first_component(mock_config, tmpdir):
     assert "finished" in perl_digest_comp_dir
 
 
+@patch("module_build.builders.mock_builder.MockBuilder.call_createrepo_c_on_dir", new=fake_call_createrepo_c_on_dir)
 @patch("module_build.builders.mock_builder.MockBuilder.get_artifacts_nevra", new=fake_get_artifacts)
 @patch("module_build.builders.mock_builder.mockbuild.config.load_config",
        return_value={"target_arch": "x86_64", "dist": "fc35"})
@@ -174,10 +179,11 @@ def test_resume_module_build_failed_to_create_batch_yaml_file(mock_config, tmpdi
     missing """
     cwd = tmpdir.mkdir("workdir").strpath
     rootdir = None
+    srpm_dir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -219,7 +225,7 @@ def test_resume_module_build_failed_to_create_batch_yaml_file(mock_config, tmpdi
     os.remove(yaml_file_path)
 
     # we run the build again on the same working directory with the resume option on
-    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir)
+    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
     with patch("module_build.builders.mock_builder.MockBuildroot.run",
                new=fake_buildroot_run):
         builder_resumed.build(module_stream, resume=True)
@@ -249,6 +255,7 @@ def test_resume_module_build_failed_to_create_batch_yaml_file(mock_config, tmpdi
     assert os.path.isfile(finished_file_path)
 
 
+@patch("module_build.builders.mock_builder.MockBuilder.call_createrepo_c_on_dir", new=fake_call_createrepo_c_on_dir)
 @patch("module_build.builders.mock_builder.MockBuilder.get_artifacts_nevra", new=fake_get_artifacts)
 @patch("module_build.builders.mock_builder.mockbuild.config.load_config",
        return_value={"target_arch": "x86_64", "dist": "fc35"})
@@ -256,10 +263,11 @@ def test_resume_module_build_continue_with_new_batch(mock_config, tmpdir):
     """ We test to resume module build when a new batch directory has failed to create. """
     cwd = tmpdir.mkdir("workdir").strpath
     rootdir = None
+    srpm_dir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -290,7 +298,7 @@ def test_resume_module_build_continue_with_new_batch(mock_config, tmpdir):
     shutil.rmtree(batch_3_path)
 
     # we run the build again on the same working directory with the resume option on
-    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir)
+    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
     with patch("module_build.builders.mock_builder.MockBuildroot.run",
                new=fake_buildroot_run):
         builder_resumed.build(module_stream, resume=True)
@@ -322,16 +330,18 @@ def test_resume_module_build_continue_with_new_batch(mock_config, tmpdir):
     assert os.path.isfile(finished_file_path)
 
 
+@patch("module_build.builders.mock_builder.MockBuilder.call_createrepo_c_on_dir", new=fake_call_createrepo_c_on_dir)
 @patch("module_build.builders.mock_builder.MockBuilder.get_artifacts_nevra", new=fake_get_artifacts)
 @patch("module_build.builders.mock_builder.mockbuild.config.load_config",
        return_value={"target_arch": "x86_64", "dist": "fc35"})
 def test_resume_module_build_continue_with_next_context(mock_config, tmpdir):
     cwd = tmpdir.mkdir("workdir").strpath
     rootdir = None
+    srpm_dir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -359,7 +369,7 @@ def test_resume_module_build_continue_with_next_context(mock_config, tmpdir):
     assert "finished" in first_context_dir
 
     # we run the build again on the same working directory with the resume option on
-    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir)
+    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
     with patch("module_build.builders.mock_builder.MockBuildroot.run",
                new=fake_buildroot_run):
         builder_resumed.build(module_stream, resume=True)
@@ -381,6 +391,7 @@ def test_resume_module_build_continue_with_next_context(mock_config, tmpdir):
 
 
 @pytest.mark.parametrize("context", ["f26devel", "f27devel"])
+@patch("module_build.builders.mock_builder.MockBuilder.call_createrepo_c_on_dir", new=fake_call_createrepo_c_on_dir)
 @patch("module_build.builders.mock_builder.MockBuilder.get_artifacts_nevra", new=fake_get_artifacts)
 @patch("module_build.builders.mock_builder.mockbuild.config.load_config",
        return_value={"target_arch": "x86_64", "dist": "fc35"})
@@ -392,10 +403,11 @@ def test_resume_module_build_do_not_continue_with_next_context_when_context_spec
 
     cwd = tmpdir.mkdir("workdir").strpath
     rootdir = None
+    srpm_dir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -426,7 +438,7 @@ def test_resume_module_build_do_not_continue_with_next_context_when_context_spec
     shutil.rmtree(batch_3_path)
 
     # we run the build again on the same working directory with the resume option on
-    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir)
+    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
     with patch("module_build.builders.mock_builder.MockBuildroot.run",
                new=fake_buildroot_run):
         builder_resumed.build(module_stream, resume=True, context_to_build=context)
@@ -450,15 +462,17 @@ def test_resume_module_build_do_not_continue_with_next_context_when_context_spec
 
 @pytest.mark.parametrize("context", ["f26devel", "f27devel"])
 @patch("module_build.builders.mock_builder.MockBuilder.get_artifacts_nevra", new=fake_get_artifacts)
+@patch("module_build.builders.mock_builder.MockBuilder.call_createrepo_c_on_dir", new=fake_call_createrepo_c_on_dir)
 @patch("module_build.builders.mock_builder.mockbuild.config.load_config",
        return_value={"target_arch": "x86_64", "dist": "fc35"})
 def test_resume_module_build_first_specify_context_and_resume_without(mock_config, context, tmpdir):
     cwd = tmpdir.mkdir("workdir").strpath
     rootdir = None
+    srpm_dir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -489,7 +503,7 @@ def test_resume_module_build_first_specify_context_and_resume_without(mock_confi
     shutil.rmtree(batch_3_path)
 
     # we run the build again on the same working directory with the resume option on
-    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir)
+    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
     with patch("module_build.builders.mock_builder.MockBuildroot.run",
                new=fake_buildroot_run):
         builder_resumed.build(module_stream, resume=True)

--- a/tests/mock/test_info.py
+++ b/tests/mock/test_info.py
@@ -1,0 +1,49 @@
+import pytest
+from pathlib import Path
+from module_build.mock.info import MockBuildInfo
+
+
+@pytest.mark.parametrize("path_as_str", [True, False])
+@pytest.mark.parametrize("srpms", [("flatpak", "nginx-devel"), ("office-sr3", "gdb")])
+def test_adding_srpm(srpms, path_as_str):
+    mock_info = MockBuildInfo()
+
+    for srpm in srpms:
+        path = f"/tmp/{srpm}" if path_as_str else Path(f"/tmp/{srpm}")
+        mock_info.add_srpm(srpm, path)
+
+    for srpm in srpms:
+        assert f"/tmp/{srpm}" == mock_info.get_srpm_path(srpm)
+
+    assert mock_info.get_srpm_count() == 2
+
+
+@pytest.mark.parametrize("path_as_str", [True, False])
+@pytest.mark.parametrize("srpms", [("flatpak", "flatpak"), ("nginx-dev", "nginx-dev")])
+def test_adding_srpm_duplicate(srpms, path_as_str):
+    mock_info = MockBuildInfo()
+
+    for idx, srpm in enumerate(srpms):
+        path = f"/tmp/{srpm}_{idx}" if path_as_str else Path(f"/tmp/{srpm}_{idx}")
+        mock_info.add_srpm(srpm, path)
+
+    assert mock_info.get_srpm_count() == 1
+    assert "_1" in mock_info.get_srpm_path(srpms[0], "_1")
+    assert "_0" in mock_info.get_srpm_path(srpms[0], "_0")
+    assert mock_info.get_srpm_path(srpms[0], "_3") is None
+
+    for srpm in srpms:
+        assert "/tmp/" in mock_info.get_srpm_path(srpm)
+
+
+@pytest.mark.parametrize("srpms", [("flatpak", "nginx-devel"), ("office-sr3", "gdb")])
+def test_adding_srpm_bad_path(srpms):
+    mock_info = MockBuildInfo()
+
+    with pytest.raises(Exception) as e:
+        for srpm in srpms:
+            invalid_path = 44
+            mock_info.add_srpm(srpm, invalid_path)
+
+    err_msg = e.value.args[0]
+    assert "Wrong path object" in err_msg

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,7 +27,7 @@ def test_debug_option(mock_config, tmpdir):
 
     Args = namedtuple("Args", ["modulemd", "mock_cfg", "debug", "workdir", "resume",
                                "module_name", "module_stream", "module_version",
-                               "add_repo", "rootdir", "module_context"])
+                               "add_repo", "rootdir", "module_context", "srpm_dir"])
 
     args = Args(modulemd=full_path,
                 mock_cfg="/etc/mock/fedora-35-x86_64.cfg",
@@ -39,7 +39,8 @@ def test_debug_option(mock_config, tmpdir):
                 module_version=None,
                 rootdir=None,
                 add_repo=[],
-                module_context=None)
+                module_context=None,
+                srpm_dir=None)
 
     with patch("module_build.cli.get_arg_parser") as mock_parser:
         mock_parser.return_value.parse_args.return_value = args
@@ -62,7 +63,7 @@ def test_reraise_exception(mock_config, tmpdir):
 
     Args = namedtuple("Args", ["modulemd", "mock_cfg", "debug", "workdir", "resume",
                                "module_name", "module_stream", "module_version",
-                               "add_repo", "rootdir", "module_context"])
+                               "add_repo", "rootdir", "module_context", "srpm_dir"])
 
     args = Args(modulemd=full_path,
                 mock_cfg="/etc/mock/fedora-35-x86_64.cfg",
@@ -74,7 +75,8 @@ def test_reraise_exception(mock_config, tmpdir):
                 module_version=None,
                 rootdir=None,
                 add_repo=[],
-                module_context=None)
+                module_context=None,
+                srpm_dir=None)
 
     with patch("module_build.cli.get_arg_parser") as mock_parser:
         mock_parser.return_value.parse_args.return_value = args
@@ -116,7 +118,7 @@ def test_choose_context_to_build(tmpdir):
 
     Args = namedtuple("Args", ["modulemd", "mock_cfg", "debug", "workdir", "resume",
                                "module_name", "module_stream", "module_version",
-                               "add_repo", "rootdir", "module_context"])
+                               "add_repo", "rootdir", "module_context", "srpm_dir"])
 
     context_to_build = "f26devel"
 
@@ -130,7 +132,8 @@ def test_choose_context_to_build(tmpdir):
                 module_version=None,
                 rootdir=None,
                 add_repo=[],
-                module_context=context_to_build)
+                module_context=context_to_build,
+                srpm_dir=None)
 
     with patch("module_build.cli.get_arg_parser") as mock_parser:
         mock_parser.return_value.parse_args.return_value = args

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,10 @@ usedevelop = true
 sitepackages = true
 whitelist_externals =
     flake8
-    py.test
-deps = -r{toxinidir}/test-requirements.txt
+    pytest
+deps =
+    -Ur{toxinidir}/test-requirements.txt
+    -Ur{toxinidir}/requirements.txt
 commands =
     pytest -v \
         --cov module_build \


### PR DESCRIPTION
This PR mainly adds possibility to build modules from local SRPM but it also fixes few things.

Fixes:

- typo in tox file
- createrepo_c changes in return code

New:

- Support for mock version 3. Only `mockbuild.config` needs adjusting. Unfortunately mockbuild package is part of mock rpm and it is not distributed in any other places and because of that `__version__` attribute is missing.
- Global constants to improve code readability in future.
- New MockConfig class. This is new abstraction layer for customizing mock cnf file instead of directly modifying it in mockbuild.
- New MockBuildInfo class. This class should replace whole mockbuild tracking (context info, status info etc). For now it include only SRPM logic.
- New dependency for handling rpm archives. This is the only one that mentioned srpm support. It should not cause much overhaul. I'm nut sure how rpm archive looks like but it would be best to read only header to memory, find correct file in list of files in it and read  only .spec file based of offset and size.
- SRPM logic with tests.

We are missing tests to cover `_map_srpm_files`. This will be covered in another PR same for MockConfig class.