### PR TITLE
Add test coverage for srpm mapping #2

### DIFF
--- a/module_build/builders/mock_builder.py
+++ b/module_build/builders/mock_builder.py
@@ -1,20 +1,19 @@
 import copy
 import os
 import shutil
-import tempfile
 import subprocess
+import tempfile
 from collections import OrderedDict
 from pathlib import Path
+
 import libarchive
-
 import mockbuild.config
-from module_build.constants import SPEC_EXTENSION, SRPM_EXTENSIONS, SRPM_MAPPING_FILENAME
-
+from module_build.constants import SPEC_EXTENSION, SRPM_EXTENSIONS
 from module_build.log import logger
-from module_build.metadata import (generate_and_populate_output_mmd, mmd_to_str,
-                                   generate_module_stream_version)
-from module_build.mock.info import MockBuildInfo
+from module_build.metadata import (generate_and_populate_output_mmd,
+                                   generate_module_stream_version, mmd_to_str)
 from module_build.mock.config import MockConfig
+from module_build.mock.info import MockBuildInfo
 from module_build.modulemd import Modulemd
 
 

--- a/module_build/constants.py
+++ b/module_build/constants.py
@@ -9,7 +9,7 @@ KEY_MODULE_ENABLE = "config_opts['module_enable']"
 KEY_MACROS_PREFIX = "config_opts['macros']"
 
 # Mock
-SRPM_EXTENSIONS = [".rpm", ".src"]
+SRPM_EXTENSION = "src.rpm"
 SPEC_EXTENSION = ".spec"
 
 SRPM_MAPPING_FILENAME = "srpm_mapping"

--- a/module_build/constants.py
+++ b/module_build/constants.py
@@ -1,6 +1,12 @@
 # Config
+KEY_SCM_PREFIX_ALL = "config_opts['scm"
+KEY_SCM_ENABLE = "config_opts['scm']"
+KEY_SCM_METHOD = "config_opts['scm_opts']['method']"
+KEY_SCM_PACKAGE = "config_opts['scm_opts']['package']"
+KEY_SCM_BRANCH = "config_opts['scm_opts']['branch']"
 KEY_MODULE_INSTALL = "config_opts['module_install']"
 KEY_MODULE_ENABLE = "config_opts['module_enable']"
+KEY_MACROS_PREFIX = "config_opts['macros']"
 
 # Mock
 SRPM_EXTENSIONS = [".rpm", ".src"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+from subprocess import DEVNULL, run
+from tempfile import NamedTemporaryFile
+
+import pytest
+
+
+def create_fake_spec(tmp_srpm_dir, name, version=None, release=None):
+    with NamedTemporaryFile(mode="w", suffix=".spec", dir=tmp_srpm_dir, delete=False) as tmp_spec:
+        tmp_spec.write(
+            f"Name: {name}\nVersion: {version or '1.22.4'}\nRelease: {release or '2'}\nSummary: Simplicity\nLicense: MIT\n%description")
+        return tmp_spec.name
+
+
+@pytest.fixture
+def create_fake_srpm(request, tmp_path):
+    tmp_dir = str(tmp_path.resolve())
+    for data in request.param:
+        spec_path = create_fake_spec(**data, tmp_srpm_dir=tmp_dir)
+        result = run(["rpmbuild", "-bs", "-D", f"_srcrpmdir {tmp_dir}", "-D", f"_topdir {tmp_dir}", f"{spec_path}"], stdout=DEVNULL)
+
+        if result.returncode != 0:
+            raise Exception(f"Error creating fake srpm: {result.returncode}")
+
+    return tmp_dir

--- a/tests/mock/conftest.py
+++ b/tests/mock/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+from module_build.mock.config import MockConfig
+from tests import get_full_data_path
+
+
+@pytest.fixture
+def mock_cfg(path="mock_cfg/fedora-35-x86_64.cfg"):
+    mock_cfg_path = get_full_data_path(path)
+    return MockConfig(mock_cfg_path)

--- a/tests/mock/test_config.py
+++ b/tests/mock/test_config.py
@@ -1,0 +1,56 @@
+
+import tempfile
+
+from module_build.constants import (KEY_MACROS_PREFIX, KEY_SCM_BRANCH,
+                                    KEY_SCM_ENABLE, KEY_SCM_METHOD,
+                                    KEY_SCM_PACKAGE)
+
+
+def test_enable_disable_mbs(mock_cfg):
+    """
+        Test enabling/disabling MBS funtionality in mock config.
+    """
+    mock_cfg.enable_mbs("dist", "pkg_name", "branch_name")
+
+    mbs_keys = {KEY_SCM_ENABLE, KEY_SCM_METHOD, KEY_SCM_PACKAGE,
+                KEY_SCM_BRANCH}
+
+    assert 4 == len(mock_cfg.content)
+    assert mbs_keys.issubset(mock_cfg.content)
+
+    mock_cfg.disable_mbs()
+
+    assert 0 == len(mock_cfg.content)
+    for key in mbs_keys:
+        assert key not in mock_cfg.content
+
+
+def test_adding_macros(mock_cfg):
+    """
+        Test adding macros to mock config using add_macros method.
+    """
+    macros = ("__kick_runtime true", "_modify go")
+
+    mock_cfg.add_macros(macros)
+
+    for macro in macros:
+        key, value = macro.split(" ")
+        key = f"{KEY_MACROS_PREFIX}['{key}']"
+        assert key in mock_cfg.content
+        assert mock_cfg.content[key] == value
+
+
+def test_write_config(mock_cfg):
+    """
+        Test writing mock config file to directory and validate file content.
+    """
+    mock_cfg.enable_mbs("gistgit", "nginx", "f55")
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        mock_cfg_path = mock_cfg.write_config(tmp_dir, "nginx")
+
+        with open(mock_cfg_path) as f:
+            lines = f.readlines()
+
+            assert KEY_SCM_ENABLE in lines[0]
+            assert "include" in lines[4]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,10 +3,10 @@ from collections import namedtuple
 from unittest.mock import patch
 
 import pytest
-
-from module_build.cli import main, get_arg_parser
+from module_build.cli import get_arg_parser, main
 from module_build.stream import ModuleStream
-from tests import get_full_data_path, TestException
+
+from tests import TestException, get_full_data_path
 
 
 def fake_raise_exception(self):


### PR DESCRIPTION
_This is based on PR #7 , so it should be marge after #7 is closed._

This PR adds _bare minimum_ to create real/fake but valid SRPM. With this we can properly cover testing srpm mapping method instead of mocking it.