### PR TITLE
Add multprocess queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,3 +153,12 @@ This option allows to build all components directly from SRPM instead of utilizi
 ```
 $ module-build -f flatpak-runtime.yaml -c /etc/mock/fedora-35-x86_64.cfg --srpm-dir /path/to/srpms  ./workdir
 ```
+
+## Building a module in multiprocess mode.
+This option allows to build components simultaneously. To utilize this mode, please specify amount of `--workers` higher than `1`.
+This mode requires to turn off logger stdout by `--no-stdout` argument.
+<br />
+<br />
+```
+$ module-build -f perl-bootstrap-new.yaml -c /etc/mock/fedora-35-x86_64.cfg --module-name=perl-bootstrap -w 2 --no-stdout /workdir
+```

--- a/module_build/builders/mock_builder.py
+++ b/module_build/builders/mock_builder.py
@@ -4,7 +4,10 @@ import shutil
 import subprocess
 import tempfile
 from collections import OrderedDict
+from multiprocessing import Manager, Pool
 from pathlib import Path
+from sys import stdout
+from time import sleep
 
 import libarchive
 import mockbuild.config
@@ -20,14 +23,17 @@ from module_build.modulemd import Modulemd
 class MockBuilder:
     # TODO enable building only specific contexts
     # TODO enable multiprocess queues for component building.
-    def __init__(self, mock_cfg_path, workdir, external_repos, rootdir, srpm_dir):
+    def __init__(self, mock_cfg_path, workdir, external_repos, rootdir, srpm_dir, workers):
         self.states = ["init", "building", "failed", "finished"]
         self.workdir = workdir
         self.mock_cfg_path = mock_cfg_path
         self.external_repos = external_repos
         self.rootdir = rootdir
+        self.workers = workers
 
         self.mock_info = MockBuildInfo()
+
+        # Create SRPM mapping
         if srpm_dir:
             self._map_srpm_files(srpm_dir)
 
@@ -39,8 +45,7 @@ class MockBuilder:
 
         if context_to_build:
             if context_to_build not in self.build_contexts:
-                raise Exception("The '{context}' does not exists in this module stream!".format(
-                    context=context_to_build))
+                raise Exception("The '{context}' does not exists in this module stream!".format(context=context_to_build))
 
         if resume:
             msg = "------------- Resuming Module Build --------------"
@@ -63,9 +68,8 @@ class MockBuilder:
                 continue
 
             msg = "Building context '{context}' of module stream '{module}:{stream}'...".format(
-                context=context_name,
-                module=module_stream.name,
-                stream=module_stream.stream)
+                context=context_name, module=module_stream.name, stream=module_stream.stream
+            )
             logger.info(msg)
             # we create a dir for the contexts where we will store everything related to a `context`
             if "dir" not in build_context:
@@ -88,8 +92,7 @@ class MockBuilder:
                 batch = build_context["build_batches"][position]
 
                 if batch["batch_state"] == self.states[3] and resume:
-                    msg = ("The batch number '{num}' from context '{context}' state is set "
-                           "to '{state}'. Skipping...").format(
+                    msg = ("The batch number '{num}' from context '{context}' state is set to '{state}'. Skipping...").format(
                         context=context_name,
                         state=self.states[3],
                         num=position,
@@ -106,14 +109,16 @@ class MockBuilder:
                 build_context["status"]["current_build_batch"] = position
                 build_context["build_batches"][position]["batch_state"] = self.states[1]
 
+                # Setup Pool queue for Buildroots. This needs to be setup every time we start new batch because
+                # old Pool cannot be reused. Setting up workers is expensive but amount of batches shoould be low.
+                self.pool = self._create_workers_pool(self.workers) if self.workers > 1 else None
+
                 for index, component in enumerate(batch["components"]):
 
                     if batch["curr_comp"] > index and resume:
-                        msg = ("The component '{name}' of batch number '{num}' of "
-                               "context '{context}' is already built. Skipping...").format(
-                                   name=component["name"],
-                                   num=position,
-                                   context=context_name)
+                        msg = ("The component '{name}' of batch number '{num}' of context '{context}' is already built. Skipping...").format(
+                            name=component["name"], num=position, context=context_name
+                        )
                         logger.info(msg)
                         continue
 
@@ -125,44 +130,73 @@ class MockBuilder:
                     else:
                         srpm_path = ""
 
-                    msg = "Building component {index} out of {all}...".format(
-                        index=index + 1,
-                        all=len(batch["components"]))
+                    msg = "Building component {index} out of {all}...".format(index=index + 1, all=len(batch["components"]))
                     logger.info(msg)
 
-                    msg = ("Building component '{name}' out of batch '{batch}' from context"
-                           " '{context}'...").format(name=component["name"],
-                                                     batch=position,
-                                                     context=context_name)
+                    msg = ("Building component '{name}' out of batch '{batch}' from context '{context}'...").format(
+                        name=component["name"], batch=position, context=context_name
+                    )
                     logger.info(msg)
 
                     build_context["build_batches"][position]["curr_comp"] = index
                     build_context["build_batches"][position]["curr_comp_state"] = self.states[1]
 
-                    msg = "Generating mock config for component '{name}'...".format(
-                        name=component["name"]
-                    )
+                    msg = "Generating mock config for component '{name}'...".format(name=component["name"])
                     logger.info(msg)
                     # we prepare a mock config for the mock buildroot.
-                    mock_cfg = self.generate_and_process_mock_cfg(component, context_name,
-                                                                  position)
+                    mock_cfg = self.generate_and_process_mock_cfg(component, context_name, position)
 
-                    msg = "Initializing mock buildroot for component '{name}'...".format(
-                        name=component["name"]
-                    )
+                    msg = "Initializing mock buildroot for component '{name}'...".format(name=component["name"])
                     logger.info(msg)
 
-                    buildroot = MockBuildroot(component, mock_cfg, batch["dir"], position,
-                                              build_context["modularity_label"],
-                                              build_context["rpm_suffix"],
-                                              batch_repo, self.external_repos, self.rootdir, srpm_path)
+                    if self.pool:
+                        self.pool.add_job(
+                            component,
+                            mock_cfg,
+                            batch["dir"],
+                            position,
+                            build_context["modularity_label"],
+                            build_context["rpm_suffix"],
+                            batch_repo,
+                            self.external_repos,
+                            self.rootdir,
+                            srpm_path,
+                        )
+                    else:
+                        buildroot = MockBuildroot(
+                            component,
+                            mock_cfg,
+                            batch["dir"],
+                            position,
+                            build_context["modularity_label"],
+                            build_context["rpm_suffix"],
+                            batch_repo,
+                            self.external_repos,
+                            self.rootdir,
+                            srpm_path,
+                        )
 
-                    buildroot.run()
+                        buildroot.run()
 
-                    batch["finished_builds"] += buildroot.get_artifacts()
+                        # In Pool mode to avoid compilications with shared memory
+                        # aritifacts are returned after successfoul build in separated process.
+                        batch["finished_builds"] += buildroot.get_artifacts()
 
-                    build_context["build_batches"][position]["curr_comp_state"] = self.states[3]
-                    build_context["status"]["num_finished_comps"] += 1
+                        # Using Pool mode, BUILDING status will be assigned not when task is selected from the pool
+                        # but when it's added to pool.
+                        build_context["build_batches"][position]["curr_comp_state"] = self.states[3]
+                        # This is not gonna be accurate because there is no shareded memory to update it.
+                        # (except proxy which is slow)
+                        build_context["status"]["num_finished_comps"] += 1
+
+                # Let's wait for all compnents to finish and update artifacts and some build data.
+                if self.pool:
+                    self.pool.wait()
+                    build_context["status"]["num_finished_comps"] = int(self.pool.finished_tasks)
+                    batch["finished_builds"] = list(self.pool.artifacts)
+
+                    if self.pool.failed:
+                        raise Exception("Some components failed during build process. Please investigate.")
 
                 # when the batch has finished building all its components, we will turn the batch
                 # dir into a module stream. `finalize_batch` will add a modules.yaml file so the dir
@@ -173,6 +207,11 @@ class MockBuilder:
 
             build_context["status"]["state"] = self.states[3]
             self.finalize_build_context(context_name)
+
+    def _create_workers_pool(self, processess):
+        logger.info(f"Creating pool with {processess} mock workers...")
+
+        return MockBuildPool(processess)
 
     def _map_srpm_files(self, srpm_dir):
         """
@@ -262,9 +301,7 @@ class MockBuilder:
                 prev_batches = [b for b in sorted_build_batches[:index]]
                 # for each previous batch we add a batch modular stream dependency
                 for b in prev_batches:
-                    build_batches[order]["modular_batch_deps"].append("batch{b}:{b}".format(
-                        b=b
-                    ))
+                    build_batches[order]["modular_batch_deps"].append("batch{b}:{b}".format(b=b))
 
         msg = "The following build batches where identified according to the buildorder:"
         logger.info(msg)
@@ -283,9 +320,9 @@ class MockBuilder:
             {deps}
             components:
             {comp_names}
-            ---------------------""".format(order=order, count=len(comp_names),
-                                            comp_names=comp_names,
-                                            deps=build_batches[order]["modular_batch_deps"])
+            ---------------------""".format(
+                order=order, count=len(comp_names), comp_names=comp_names, deps=build_batches[order]["modular_batch_deps"]
+            )
         logger.info(msg_batch)
 
         msg = "Total build batch count: {num}".format(num=len(sorted_build_batches))
@@ -305,8 +342,7 @@ class MockBuilder:
         # Support for mock2 and mock3
         # mockbuild is missing __version__ attribute so we are handling Exception
         try:
-            mock_cfg = mockbuild.config.load_config(mock_path, self.mock_cfg_path, None,
-                                                    module_stream.version, mock_path)
+            mock_cfg = mockbuild.config.load_config(mock_path, self.mock_cfg_path, None, module_stream.version, mock_path)
         except TypeError:
             mock_cfg = mockbuild.config.load_config(mock_path, self.mock_cfg_path, None)
 
@@ -317,9 +353,13 @@ class MockBuilder:
         if "target_arch" in mock_cfg:
             self.arch = mock_cfg["target_arch"]
         else:
-            raise Exception(("Your mock configuration file does not provide the information about "
-                             "the architecture for which the module stream should be build. Please"
-                             " inlcude the `target_arch` config option in your initial mock cfg!"))
+            raise Exception(
+                (
+                    "Your mock configuration file does not provide the information about "
+                    "the architecture for which the module stream should be build. Please"
+                    " inlcude the `target_arch` config option in your initial mock cfg!"
+                )
+            )
 
         buildroot_profiles = {}
         srpm_buildroot_profiles = {}
@@ -327,8 +367,7 @@ class MockBuilder:
             for repo in self.external_repos:
                 mi = Modulemd.ModuleIndex.new()
                 repodata_path = repo + "/repodata"
-                yaml_file = [f for f in os.listdir(repodata_path) if f.endswith(
-                    "modules.yaml.gz")]
+                yaml_file = [f for f in os.listdir(repodata_path) if f.endswith("modules.yaml.gz")]
 
                 if yaml_file:
                     yaml_file_path = repodata_path + "/" + yaml_file[0]
@@ -346,8 +385,7 @@ class MockBuilder:
                             buildroot_profiles[module_stream_str] = stream_profile
 
                         if "srpm-buildroot" in profiles:
-                            stream_profile = "{stream}/srpm-buildroot".format(
-                                stream=module_stream_str)
+                            stream_profile = "{stream}/srpm-buildroot".format(stream=module_stream_str)
                             srpm_buildroot_profiles[module_stream_str] = stream_profile
 
         build_contexts = OrderedDict()
@@ -372,7 +410,7 @@ class MockBuilder:
                     "current_build_batch": 0,
                     "num_components": len(module_stream.components),
                     "num_finished_comps": 0,
-                }
+                },
             }
 
             if buildroot_profiles:
@@ -396,15 +434,14 @@ class MockBuilder:
     def create_build_context_dir(self, context_name):
         if not self.build_contexts:
             # TODO make this to a custom exception
-            raise Exception(("No `build_contexts` metadata found! Please run the `create_build_"
-                             "contexts` method before creating directories for contexts."))
+            raise Exception(
+                ("No `build_contexts` metadata found! Please run the `create_build_ contexts` method before creating directories for contexts.")
+            )
 
-        context_dir_path = os.path.join(self.workdir,
-                                        self.build_contexts[context_name]["nsvca"])
+        context_dir_path = os.path.join(self.workdir, self.build_contexts[context_name]["nsvca"])
         os.makedirs(context_dir_path)
 
-        msg = "Created dir for '{context}' context: {path}".format(context=context_name,
-                                                                   path=context_dir_path)
+        msg = "Created dir for '{context}' context: {path}".format(context=context_name, path=context_dir_path)
         logger.info(msg)
 
         return context_dir_path
@@ -412,13 +449,13 @@ class MockBuilder:
     def create_build_batch_dir(self, context_name, batch_num):
         if not self.build_contexts:
             # TODO make this to a custom exception
-            raise Exception(("No `build_contexts` metadata found! Please run the `create_build_"
-                             "contexts` method before creating directories for contexts."))
+            raise Exception(
+                ("No `build_contexts` metadata found! Please run the `create_build_ contexts` method before creating directories for contexts.")
+            )
 
-        batches_dir_path = os.path.join(self.workdir,
-                                        self.build_contexts[context_name]["nsvca"],
-                                        "build_batches",
-                                        "batch_{batch_num}".format(batch_num=batch_num))
+        batches_dir_path = os.path.join(
+            self.workdir, self.build_contexts[context_name]["nsvca"], "build_batches", "batch_{batch_num}".format(batch_num=batch_num)
+        )
         os.makedirs(batches_dir_path)
 
         msg = "Created dir for batch number {num} from '{context}' context: {path}".format(
@@ -485,12 +522,11 @@ class MockBuilder:
             context = "b{num}".format(num=position)
             version = generate_module_stream_version()
             if position + 1 == num_batches:
-                description = ("This module stream is a buildorder modular dependency for "
-                               "batch_{last_batch}.").format(last_batch=num_batches)
+                description = ("This module stream is a buildorder modular dependency for batch_{last_batch}.").format(last_batch=num_batches)
             else:
-                description = ("This module stream is a buildorder modular dependency for "
-                               "batch_{num}-{last_batch}.").format(num=position + 1,
-                                                                   last_batch=num_batches)
+                description = ("This module stream is a buildorder modular dependency for batch_{num}-{last_batch}.").format(
+                    num=position + 1, last_batch=num_batches
+                )
             summary = description
             mod_license = "MIT"
             # for each new batch mmd we want a copy of the modular dependencies which are
@@ -506,9 +542,9 @@ class MockBuilder:
 
             artifacts = self.get_artifacts_nevra(build_batch["finished_builds"])
 
-            mmd = generate_and_populate_output_mmd(name, stream, context, version, description,
-                                                   summary, mod_license, components,
-                                                   artifacts, modular_deps)
+            mmd = generate_and_populate_output_mmd(
+                name, stream, context, version, description, summary, mod_license, components, artifacts, modular_deps
+            )
 
             mmd_str = mmd_to_str(mmd)
 
@@ -524,9 +560,9 @@ class MockBuilder:
             with open(file_path, "w") as f:
                 f.write(mmd_str)
 
-            msg = ("Batch number {position} is defined as modular batch dependency for batches "
-                   "{num}-{last_batch}").format(position=position, num=position + 1,
-                                                last_batch=last_batch)
+            msg = ("Batch number {position} is defined as modular batch dependency for batches {num}-{last_batch}").format(
+                position=position, num=position + 1, last_batch=last_batch
+            )
             logger.info(msg)
             msg = "Modular metadata written to: {path}".format(path=file_path)
 
@@ -551,19 +587,17 @@ class MockBuilder:
         logger.info(msg)
 
         mock_cmd = ["createrepo_c", dir]
-        proc = subprocess.Popen(mock_cmd)
+        proc = subprocess.Popen(mock_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         out, err = proc.communicate()
 
         if proc.returncode != 0:
-            err_msg = "Command '%s' returned non-zero value %d%s" % (mock_cmd, proc.returncode,
-                                                                     out)
+            err_msg = "Command '%s' returned non-zero value %d%s" % (mock_cmd, proc.returncode, out)
             raise RuntimeError(err_msg)
 
         return out, err
 
     def finalize_build_context(self, context_name):
-        msg = "Context '{name}' finished building all its batches...".format(
-            name=context_name)
+        msg = "Context '{name}' finished building all its batches...".format(name=context_name)
         logger.info(msg)
         context_dir = self.build_contexts[context_name]["dir"]
         final_repo_dir = context_dir + "/final_repo"
@@ -577,8 +611,7 @@ class MockBuilder:
         context = mmd.get_context()
         arch = self.build_contexts[context_name]["metadata"].arch
 
-        msg = ("Copying build artifacts from batches directories to the final repo"
-               " dir: {path}").format(path=final_repo_dir)
+        msg = ("Copying build artifacts from batches directories to the final repo dir: {path}").format(path=final_repo_dir)
         logger.info(msg)
 
         for bb in self.build_contexts[context_name]["build_batches"].values():
@@ -603,9 +636,9 @@ class MockBuilder:
         with open(mmd_yaml_file_path, "w") as f:
             f.write(mmd_str)
 
-        msg = ("Modulemd yaml file for the '{name}:{stream}:{version}:{context}' module stream has "
-               "been written to: {path}").format(name=name, stream=stream, version=version,
-                                                 context=context, path=mmd_yaml_file_path)
+        msg = ("Modulemd yaml file for the '{name}:{stream}:{version}:{context}' module stream has been written to: {path}").format(
+            name=name, stream=stream, version=version, context=context, path=mmd_yaml_file_path
+        )
 
         self.build_contexts[context_name]["final_repo_path"] = final_repo_dir
         self.build_contexts[context_name]["final_yaml_path"] = mmd_yaml_file_path
@@ -638,9 +671,7 @@ class MockBuilder:
         `rpm --queryformat` on built rpms. The NEVRA format is necesary for the artifact portion
         of a modulemd yaml file.
         """
-        rpm_cmd = ["rpm", "--queryformat",
-                   "%{NAME} %{EPOCHNUM} %{VERSION} %{RELEASE} %{ARCH} %{SOURCERPM}\n",
-                   "-qp"]
+        rpm_cmd = ["rpm", "--queryformat", "%{NAME} %{EPOCHNUM} %{VERSION} %{RELEASE} %{ARCH} %{SOURCERPM}\n", "-qp"]
 
         # TODO the whole method is dirty needs to be rewritten.
         # TODO need to add component dir to the component metadata so this will be simpler
@@ -654,8 +685,7 @@ class MockBuilder:
 
         artifacts_nevra = []
         for cwd, filenames in metadata.items():
-            out = subprocess.check_output(rpm_cmd + filenames, cwd=cwd,
-                                          universal_newlines=True)
+            out = subprocess.check_output(rpm_cmd + filenames, cwd=cwd, universal_newlines=True)
 
             nevras = out.strip().split("\n")
             for nevra in nevras:
@@ -679,9 +709,11 @@ class MockBuilder:
         context_dirs = [d for d in os.listdir(self.workdir) if d in expected_dir_names]
 
         if not context_dirs:
-            raise Exception(("No expected context directories in the working directory: {dir}\n"
-                             "Are you sure you are in the correct working directory?\n").format(
-                dir=self.workdir))
+            raise Exception(
+                ("No expected context directories in the working directory: {dir}\nAre you sure you are in the correct working directory?\n").format(
+                    dir=self.workdir
+                )
+            )
 
         msg = "Found possible context directories: {dirs}".format(dirs=context_dirs)
         logger.info(msg)
@@ -706,8 +738,7 @@ class MockBuilder:
             if finished:
                 # if the whole context is finished, then we populate the builder metadata with
                 # the current state of the context in the working directory.
-                msg = ("Context '{context}' is finished. Extracting and processing "
-                       "metadata...").format(context=context_name)
+                msg = ("Context '{context}' is finished. Extracting and processing " "metadata...").format(context=context_name)
                 logger.info(msg)
 
                 context["status"]["state"] = self.states[3]
@@ -718,8 +749,7 @@ class MockBuilder:
                     if actual_batch_name in batch_dirs:
                         batch_dir = build_batches_dir + "/" + actual_batch_name
                         finished = [f for f in os.listdir(batch_dir) if f == "finished"]
-                        msg = "Processing batch number '{num}' of context '{context}'...".format(
-                            num=position, context=context_name)
+                        msg = "Processing batch number '{num}' of context '{context}'...".format(num=position, context=context_name)
                         logger.info(msg)
 
                         # we set the dir for existing batch
@@ -728,11 +758,10 @@ class MockBuilder:
                             comp_dir = batch_dir + "/" + comp["name"]
 
                             if not os.path.isdir(comp_dir):
-                                msg = ("Component dir of component '{name}' from batch number"
-                                       " '{num}' of context '{context}' does not exist!").format(
-                                           name=comp["name"],
-                                           num=position,
-                                           context=context_name,
+                                msg = ("Component dir of component '{name}' from batch number '{num}' of context '{context}' does not exist!").format(
+                                    name=comp["name"],
+                                    num=position,
+                                    context=context_name,
                                 )
                                 raise Exception(msg)
 
@@ -752,24 +781,24 @@ class MockBuilder:
                         )
                         logger.info(msg)
                     else:
-                        msg = ("Context dir of context '{context}' is corrupted! The batch dir "
-                               "'{dir}' of batch number '{num}' does not exist!")
+                        msg = "Context dir of context '{context}' is corrupted! The batch dir '{dir}' of batch number '{num}' does not exist!"
                         raise Exception(msg)
 
             else:
                 # if the context is not finished we need to find at which batch and which
                 # component has failed last time
-                msg = ("Found an unfinished context! Context '{context}' is NOT finished. "
-                       "Extracting and processing metadata. Setting context '{context}' as "
-                       "the resume point.").format(context=context_name)
+                msg = (
+                    "Found an unfinished context! Context '{context}' is NOT finished. "
+                    "Extracting and processing metadata. Setting context '{context}' as "
+                    "the resume point."
+                ).format(context=context_name)
                 logger.info(msg)
 
                 # we set the context resume point and the state of the context to "building"
                 resume_point["context"] = context_name
                 context["status"]["state"] = self.states[1]
 
-                msg = "Finding existing batch directories of context '{context}'...".format(
-                    context=context_name)
+                msg = "Finding existing batch directories of context '{context}'...".format(context=context_name)
                 logger.info(msg)
 
                 for position in sorted(build_batches):
@@ -780,8 +809,7 @@ class MockBuilder:
                         batch_dir = build_batches_dir + "/" + actual_batch_name
 
                         finished = [f for f in os.listdir(batch_dir) if f == "finished"]
-                        msg = "Processing batch number '{num}' of context '{context}'...".format(
-                            num=position, context=context_name)
+                        msg = "Processing batch number '{num}' of context '{context}'...".format(num=position, context=context_name)
                         logger.info(msg)
 
                         # if the batch dir exist we add it to the builder metadata
@@ -807,10 +835,11 @@ class MockBuilder:
                             logger.info(msg)
                         else:
                             # if a batch is not finished we need to identify which component failed
-                            msg = ("Found an unfinished batch! Batch number '{num}' of context"
-                                   " '{context}' is NOT finished. Setting batch number '{num}' "
-                                   "of context '{context}' as the resume point.").format(
-                                num=position, context=context_name)
+                            msg = (
+                                "Found an unfinished batch! Batch number '{num}' of context"
+                                " '{context}' is NOT finished. Setting batch number '{num}' "
+                                "of context '{context}' as the resume point."
+                            ).format(num=position, context=context_name)
                             logger.info(msg)
 
                             # we set the batch resume point and the batch state to 'building'
@@ -823,19 +852,17 @@ class MockBuilder:
 
                                 # we check if the component dir exists
                                 if os.path.isdir(comp_dir):
-                                    msg = ("Processing component '{name}' of batch number '{num}' "
-                                           "of context '{context}'...").format(
-                                        num=position, context=context_name, name=comp["name"])
+                                    msg = ("Processing component '{name}' of batch number '{num}' of context '{context}'...").format(
+                                        num=position, context=context_name, name=comp["name"]
+                                    )
                                     logger.info(msg)
 
                                     finished = [f for f in os.listdir(comp_dir) if f == "finished"]
                                     # we find out if the dir is marked as finished
                                     if finished:
-                                        msg = ("Component '{name}' of batch number '{num}' of "
-                                               "context '{context}' is finished.").format(
-                                            num=position,
-                                            context=context_name,
-                                            name=comp["name"])
+                                        msg = ("Component '{name}' of batch number '{num}' of context '{context}' is finished.").format(
+                                            num=position, context=context_name, name=comp["name"]
+                                        )
                                         logger.info(msg)
                                         # if the component is finished we add the information
                                         # about the artifacts to the builder metadata
@@ -843,15 +870,16 @@ class MockBuilder:
                                         rpm_files = [f for f in filenames if f.endswith("rpm")]
                                         for rpm in rpm_files:
                                             file_path = comp_dir + "/" + rpm
-                                            build_batches[position]["finished_builds"].append(
-                                                file_path)
+                                            build_batches[position]["finished_builds"].append(file_path)
                                     else:
                                         # if an unfinished component is found we update the batch
                                         # and set the component resume point
-                                        msg = ("Found an unfinished component! Component '{name}'"
-                                               " of batch number '{num}' of context '{context}' is "
-                                               "NOT finished. Setting component '{name}' as the "
-                                               "resume point.")
+                                        msg = (
+                                            "Found an unfinished component! Component '{name}'"
+                                            " of batch number '{num}' of context '{context}' is "
+                                            "NOT finished. Setting component '{name}' as the "
+                                            "resume point."
+                                        )
                                         build_batch = build_batches[position]
                                         build_batch["batch_state"] = self.states[1]
                                         build_batch["curr_comp_state"] = self.states[0]
@@ -866,12 +894,13 @@ class MockBuilder:
                                     # component does not exist anymore and we set the resume point
                                     # to that component
                                     if "component" not in resume_point:
-                                        msg = ("Found an unfinished component! "
-                                               "It seems that the component directory of component "
-                                               "'{name}' does not exist. Component '{name}' is "
-                                               "next in line for building. Setting component "
-                                               "'{name}' as the resume point.").format(
-                                                   name=comp["name"])
+                                        msg = (
+                                            "Found an unfinished component! "
+                                            "It seems that the component directory of component "
+                                            "'{name}' does not exist. Component '{name}' is "
+                                            "next in line for building. Setting component "
+                                            "'{name}' as the resume point."
+                                        ).format(name=comp["name"])
                                         logger.info(msg)
 
                                         build_batch = build_batches[position]
@@ -886,8 +915,7 @@ class MockBuilder:
                             # is finished but was not set to the finished state.
                             if index + 1 == len(build_batches[position]["components"]):
                                 if "component" not in resume_point:
-                                    yaml_file = [f for f in os.listdir(batch_dir) if f.endswith(
-                                        "yaml")]
+                                    yaml_file = [f for f in os.listdir(batch_dir) if f.endswith("yaml")]
 
                                     if len(yaml_file):
                                         yaml_file_path = batch_dir + "/" + yaml_file[0]
@@ -899,8 +927,7 @@ class MockBuilder:
                                     build_batch["curr_comp_state"] = self.states[3]
                                     build_batch["curr_comp"] = last_comp
                                     self.finalize_batch(position, context_name)
-                                    msg = ("Batch number '{num}' of context '{context}'"
-                                           " is finished.").format(
+                                    msg = ("Batch number '{num}' of context '{context}' is finished.").format(
                                         num=position,
                                         context=context_name,
                                     )
@@ -950,28 +977,39 @@ class MockBuilder:
                 shutil.rmtree(final_repo_path)
 
             if len(resume_point) and len(resume_point) == 1 and "context" in resume_point:
-                msg = ("The context '{name}' has finished building all its batches and components."
-                       "It seems it was not finalized. Finalizing context...").format(
-                           name=context_name)
+                msg = (
+                    "The context '{name}' has finished building all its batches and components."
+                    "It seems it was not finalized. Finalizing context..."
+                ).format(name=context_name)
 
             else:
-                msg = ("According to the files and metadata provided from the working directory "
-                       "'{dir}' the resume point of the module build has been identified.\nThe "
-                       "build will resume building at component '{comp}' of build batch number "
-                       "'{num}' of build context '{context}'").format(
-                           dir=self.workdir,
-                    comp=resume_point["component"],
-                    num=resume_point["batch"],
-                    context=resume_point["context"])
+                msg = (
+                    "According to the files and metadata provided from the working directory "
+                    "'{dir}' the resume point of the module build has been identified.\nThe "
+                    "build will resume building at component '{comp}' of build batch number "
+                    "'{num}' of build context '{context}'"
+                ).format(dir=self.workdir, comp=resume_point["component"], num=resume_point["batch"], context=resume_point["context"])
         else:
-            msg = ("No resume point found! It seems all batches and components of your module "
-                   "stream are built!")
+            msg = "No resume point found! It seems all batches and components of your module " "stream are built!"
         logger.info(msg)
 
 
 class MockBuildroot:
-    def __init__(self, component, mock_cfg, batch_dir_path, batch_num, modularity_label,
-                 rpm_suffix, batch_repo, external_repos, rootdir, srpm_path):
+    def __init__(
+        self,
+        component,
+        mock_cfg,
+        batch_dir_path,
+        batch_num,
+        modularity_label,
+        rpm_suffix,
+        batch_repo,
+        external_repos,
+        rootdir,
+        srpm_path,
+        components_callback=None,
+        artifacts_callback=None,
+    ):
 
         self.finished = False
         self.component = component
@@ -985,15 +1023,28 @@ class MockBuildroot:
         self.external_repos = external_repos
         self.rootdir = rootdir
         self.srpm_path = srpm_path
+        # Multithread options
+        self.pool_mode = True if components_callback is not None else None
+        self.artifacts_callback = artifacts_callback
+        self.components_callback = components_callback
 
     def run(self):
-        mock_cmd = ["mock", "-v", "-r", self.mock_cfg_path,
-                    "--resultdir={result_dir_path}".format(result_dir_path=self.result_dir_path),
-                    "--define=modularitylabel {label}".format(label=self.modularity_label),
-                    "--define=dist {rpm_suffix}".format(
-                        rpm_suffix=self.rpm_suffix),
-                    "--addrepo={repo}".format(repo=self.batch_repo),
-                    ]
+        # To have at least some kind of knowlage of what is currently going in queue
+        # we use ProxyList to update list of currently building components.
+        if self.components_callback is not None:
+            self.components_callback.append(self.component["name"])
+
+        mock_cmd = [
+            "mock",
+            "-v",
+            "-r",
+            self.mock_cfg_path,
+            "--resultdir={result_dir_path}".format(result_dir_path=self.result_dir_path),
+            "--define=modularitylabel {label}".format(label=self.modularity_label),
+            "--define=dist {rpm_suffix}".format(rpm_suffix=self.rpm_suffix),
+            "--addrepo={repo}".format(repo=self.batch_repo),
+            f"--uniqueext={self.component['name']}",
+        ]
 
         if self.external_repos:
             for repo in self.external_repos:
@@ -1012,16 +1063,15 @@ class MockBuildroot:
         logger.info(msg)
         stdout_log_file_path = self.result_dir_path + "/mock_stdout.log"
 
-        msg = "The 'stdout' of the mock buildroot process is written to: {path}".format(
-            path=stdout_log_file_path)
+        msg = "The 'stdout' of the mock buildroot process is written to: {path}".format(path=stdout_log_file_path)
         logger.info(msg)
 
         with open(stdout_log_file_path, "w") as f:
-            proc = subprocess.Popen(mock_cmd, stdout=f, stderr=f,
-                                    universal_newlines=True)
+            proc = subprocess.Popen(mock_cmd, stdout=f, stderr=f, universal_newlines=True)
         out, err = proc.communicate()
 
-        if proc.returncode != 0:
+        # We don't won't any exceptions in Multithread mode
+        if proc.returncode != 0 and not self.pool_mode:
             err_msg = "Command '{cmd}' returned non-zero value {code}\n{err}".format(
                 cmd=mock_cmd,
                 code=proc.returncode,
@@ -1029,21 +1079,28 @@ class MockBuildroot:
             )
             raise RuntimeError(err_msg)
 
-        msg = "Mock buildroot finished build of component '{name}' successfully!".format(
-            name=self.component["name"]
-        )
+        msg = "Mock buildroot finished build of component '{name}' successfully!".format(name=self.component["name"])
         logger.info(msg)
         logger.info("---------------------------------")
 
         self.finished = True
         self._finalize_component()
 
+        # This is special handling for Poll mode...
+        if proc.returncode == 0 and self.pool_mode:
+            artifacts = self.get_artifacts
+            if artifacts:
+                self.artifacts_callback.extend([os.path.join(self.result_dir_path, f) for f in os.listdir(self.result_dir_path) if f.endswith("rpm")])
+            return self.component["name"], True
+        elif self.pool_mode:
+            return self.component["name"], False
+
+        # This is for normal mode.
         return out, err
 
     def get_artifacts(self):
         if self.finished:
-            artifacts = [os.path.join(self.result_dir_path, f)
-                         for f in os.listdir(self.result_dir_path) if f.endswith("rpm")]
+            artifacts = [os.path.join(self.result_dir_path, f) for f in os.listdir(self.result_dir_path) if f.endswith("rpm")]
 
             return artifacts
         else:
@@ -1070,3 +1127,65 @@ class MockBuildroot:
         logger.info(msg)
 
         return result_dir_path
+
+
+class MockBuildPool:
+    def __init__(self, workers):
+        self.manager = Manager()
+        self.pool = Pool(workers)
+        self.currently_running = self.manager.list()  # currently running tasks in pool
+        self.all_tasks = 0  # number of submitted taks to pool
+        self.finished_tasks = 0  # number of finished tasks
+        self.artifacts = self.manager.list()
+        self.failed = 0
+
+    def add_job(self, *args):
+        """Adds job to the queue."""
+        self.all_tasks += 1
+        self.pool.apply_async(
+            MockBuildroot(*(*args, self.currently_running, self.artifacts)).run,
+            (),
+            callback=self.callback,
+            error_callback=self.callback_error,
+        )
+        self.update_progress()
+
+    def callback(self, result):
+        """
+        Handles return informarion from Buildroot.
+
+        Args:
+            result (tuple): Component name with build status information.
+        """
+        compoment, result = result
+        self.currently_running.remove(compoment)
+        if result:
+            self.finished_tasks += 1
+        else:
+            self.failed += 1
+        self.update_progress()
+
+    def callback_error(self):
+        """
+        Handle exception from different process. This should never happend
+        but it might if exception is thrown in Buildroot. We add failure to avoid
+        running another batch.
+        """
+        self.failed += 1
+        self.update_progress()
+
+    def update_progress(self):
+        """It updates stdout with current pool information"""
+        sleep(0.2)  # This is here because Manager() is slow
+        status_numbers = f"{self.finished_tasks}/{self.failed}/{self.all_tasks-self.failed-self.finished_tasks}"
+        stdout.write("\033[K")
+        print(
+            f"Finished/Failed/Queue ({status_numbers}): {self.currently_running}",
+            end="\r",
+            flush=True,
+        )
+
+    def wait(self):
+        """Waits for all tasks in pool to finish"""
+        self.pool.close()
+        self.pool.join()

--- a/module_build/builders/mock_builder.py
+++ b/module_build/builders/mock_builder.py
@@ -1137,7 +1137,17 @@ class MockBuildPool:
         self.all_tasks = 0  # number of submitted taks to pool
         self.finished_tasks = 0  # number of finished tasks
         self.artifacts = self.manager.list()
-        self.failed = 0
+        self._failed = 0
+
+    # We need it to be as attr to be able to override in test
+    # cases scenarios.
+    @property
+    def failed(self):
+        return self._failed
+
+    @failed.setter
+    def failed(self, failed):
+        self._failed = failed
 
     def add_job(self, *args):
         """Adds job to the queue."""
@@ -1162,7 +1172,7 @@ class MockBuildPool:
         if result:
             self.finished_tasks += 1
         else:
-            self.failed += 1
+            self._failed += 1
         self.update_progress()
 
     def callback_error(self):
@@ -1171,7 +1181,7 @@ class MockBuildPool:
         but it might if exception is thrown in Buildroot. We add failure to avoid
         running another batch.
         """
-        self.failed += 1
+        self._failed += 1
         self.update_progress()
 
     def update_progress(self):

--- a/module_build/cli.py
+++ b/module_build/cli.py
@@ -6,13 +6,13 @@ import traceback
 
 from module_build.builders.mock_builder import MockBuilder
 from module_build.log import init_logging, logger
-from module_build.metadata import (load_modulemd_file_from_path,
-                                   generate_module_stream_version)
+from module_build.metadata import (generate_module_stream_version,
+                                   load_modulemd_file_from_path)
 from module_build.stream import ModuleStream
 
 
 class FullPathAction(argparse.Action):
-    """ A custom argparse action which converts all relative paths to absolute. """
+    """A custom argparse action which converts all relative paths to absolute."""
 
     def __call__(self, parser, args, values, option_string=None):
         full_path = self._get_full_path(values)
@@ -35,67 +35,74 @@ class FullPathAction(argparse.Action):
 
 
 def get_arg_parser():
-    description = (
-        """
+    description = """
         module-build is a command line utility which enables you to build modules locally.
         """
-    )
-    parser = argparse.ArgumentParser("module-build", description=description,
-                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument("workdir", type=str, action=FullPathAction,
-                        help=("The working directory where the build of a module stream will"
-                              " happen."))
+    parser = argparse.ArgumentParser("module-build", description=description, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("workdir", type=str, action=FullPathAction, help=("The working directory where the build of a module stream will" " happen."))
 
     group = parser.add_mutually_exclusive_group(required=True)
 
-    group.add_argument("-f", "--modulemd", type=str, action=FullPathAction,
-                       help="Path to the modulemd yaml file")
+    group.add_argument("-f", "--modulemd", type=str, action=FullPathAction, help="Path to the modulemd yaml file")
 
     # group.add_argument("-g", "--git-branch", type=str,
     #                   help=("URL to the git branch where the modulemd yaml file resides."))
 
-    parser.add_argument("-c", "--mock-cfg", help="Path to the mock config.",
-                        default=".", type=str, required=True,
-                        action=FullPathAction)
+    parser.add_argument("-c", "--mock-cfg", help="Path to the mock config.", default=".", type=str, required=True, action=FullPathAction)
+    parser.add_argument("-o", "--no-stdout", action="store_true", help="If set logger output in stdout will not be displayed.")
+    parser.add_argument("-w", "--workers", type=int, default=1, help="When set to value higher than 1, will use multiprocess mode.")
+    parser.add_argument("-r", "--resume", action="store_true", help="If set it will try to continue the build where it failed last time.")
 
-    parser.add_argument("-r", "--resume", action="store_true",
-                        help="If set it will try to continue the build where it failed last time.")
+    parser.add_argument(
+        "-n",
+        "--module-name",
+        type=str,
+        help=("You can define the module name with this option if it is not set in the provided modulemd yaml file."),
+    )
 
-    parser.add_argument("-n", "--module-name", type=str,
-                        help=("You can define the module name with this option if it is not"
-                              " set in the provided modulemd yaml file."))
+    parser.add_argument(
+        "-s",
+        "--module-stream",
+        type=str,
+        help=("You can define the module stream name with this option if it is not set in the provided modulemd yaml file."),
+    )
 
-    parser.add_argument("-s", "--module-stream", type=str,
-                        help=("You can define the module stream name with this option if it is not"
-                              " set in the provided modulemd yaml file."))
+    parser.add_argument(
+        "-l",
+        "--module-version",
+        type=int,
+        help=(
+            "You can define the module stream name with this option. If it is not"
+            " set the current unix timestamp will be used instead. This option is"
+            " also required when using the resume feature. You can specify which "
+            "module stream version you want to resume."
+        ),
+    )
 
-    parser.add_argument("-l", "--module-version", type=int,
-                        help=("You can define the module stream name with this option. If it is not"
-                              " set the current unix timestamp will be used instead. This option is"
-                              " also required when using the resume feature. You can specify which "
-                              "module stream version you want to resume."))
+    parser.add_argument(
+        "-m",
+        "--srpm-dir",
+        type=str,
+        help=("Path to directory with SRPMs. When set, all module components will be build from given sources."),
+        action=FullPathAction,
+    )
 
-    parser.add_argument("-m", "--srpm-dir", type=str,
-                        help=("Path to directory with SRPMs. When set, all module components will be"
-                              " build from given sources."),
-                        action=FullPathAction)
-
-    parser.add_argument("-g", "--module-context", type=str,
-                        help=("When set it will only build the selected context from the modules"
-                              " stream."))
+    parser.add_argument("-g", "--module-context", type=str, help=("When set it will only build the selected context from the modules stream."))
     # TODO verbose is not implemented
     # parser.add_argument("-v", "--verbose", action="store_true",
     #                     help="Will display all output to stdout.")
 
-    parser.add_argument("-d", "--debug", action="store_true",
-                        help="When the module build fails it will start the python `pdb` debugger.")
+    parser.add_argument("-d", "--debug", action="store_true", help="When the module build fails it will start the python `pdb` debugger.")
     parser.set_defaults(add_repo=[])
-    parser.add_argument("-p", "--add-repo", type=str, action=FullPathAction,
-                        help=("With this option you can provide external RPM repositories to the"
-                              " buildroots of the module build. Can be used multiple times."))
+    parser.add_argument(
+        "-p",
+        "--add-repo",
+        type=str,
+        action=FullPathAction,
+        help=("With this option you can provide external RPM repositories to the buildroots of the module build. Can be used multiple times."),
+    )
 
-    parser.add_argument("-t", "--rootdir", type=str,
-                        help=("Provides a new location for you buildroots."))
+    parser.add_argument("-t", "--rootdir", type=str, help=("Provides a new location for you buildroots."))
 
     return parser
 
@@ -105,14 +112,16 @@ def main():
     args = parser.parse_args()
 
     if args.resume and args.module_version is None:
-        parser.error("when using -r/--resume you need also set -l/--module-version so we can "
-                     "can identify which contexts build need to be resumed.")
+        parser.error("when using -r/--resume you need also set -l/--module-version so we can can identify which contexts build need to be resumed.")
+
+    if args.workers > 1 and not args.no_stdout:
+        parser.error("Multiprocess mode requires disabling stdout output -o/--no-stdout.")
 
     # TODO this needs to be updated when scm checkout will be added
     yaml_filename = args.modulemd.split("/")[-1].rsplit(".", 1)[0]
-    init_logging(args.workdir, yaml_filename, logger)
+    init_logging(args.workdir, yaml_filename, logger, args.no_stdout)
 
-# PHASE1: Load metadata and configuration provided by the user
+    # PHASE1: Load metadata and configuration provided by the user
     logger.info("Processing provided module stream metadata...")
     if args.modulemd:
         mmd = load_modulemd_file_from_path(args.modulemd)
@@ -142,9 +151,7 @@ def main():
         # PHASE2: init the builder
     if args.module_context:
         log_msg = "Starting to build the '{name}:{stream}:{context}' of the module stream.".format(
-            name=module_stream.name,
-            stream=module_stream.stream,
-            context=args.module_context
+            name=module_stream.name, stream=module_stream.stream, context=args.module_context
         )
     else:
         log_msg = "Starting to build the '{name}:{stream}' module stream.".format(
@@ -155,10 +162,9 @@ def main():
     logger.info(log_msg)
 
     # TODO add exceptions
-    mock_builder = MockBuilder(args.mock_cfg, args.workdir,
-                               args.add_repo, args.rootdir, args.srpm_dir)
+    mock_builder = MockBuilder(args.mock_cfg, args.workdir, args.add_repo, args.rootdir, args.srpm_dir, args.workers)
 
-# PHASE3: try to build the module stream
+    # PHASE3: try to build the module stream
     try:
         mock_builder.build(module_stream, args.resume, context_to_build=args.module_context)
     except Exception:
@@ -167,14 +173,16 @@ def main():
 
         if args.debug:
             print(formated_tb)
-            msg = ("The program is now in debug mode after encountering an exception."
-                   " When encountering an error the `pdb` python debugger is"
-                   " started. See the following variables to check the state of the build:\n\n"
-                   "`formated_tb` - formated traceback of the exception\n"
-                   "`exc_info` - tuple with the exception information\n"
-                   "`module_stream` - object of module stream metadata loaded from your "
-                   "modulemd file\n"
-                   "`mock_builder` - object which holds the state of your module build\n\n")
+            msg = (
+                "The program is now in debug mode after encountering an exception."
+                " When encountering an error the `pdb` python debugger is"
+                " started. See the following variables to check the state of the build:\n\n"
+                "`formated_tb` - formated traceback of the exception\n"
+                "`exc_info` - tuple with the exception information\n"
+                "`module_stream` - object of module stream metadata loaded from your "
+                "modulemd file\n"
+                "`mock_builder` - object which holds the state of your module build\n\n"
+            )
             logger.info(msg)
 
             pdb.set_trace()
@@ -182,7 +190,7 @@ def main():
             print(formated_tb)
             raise exc_info[1]
 
-# PHASE4: Make a final report on the module stream build
+    # PHASE4: Make a final report on the module stream build
     # TODO implement final_report
     mock_builder.final_report()
 

--- a/module_build/log.py
+++ b/module_build/log.py
@@ -5,12 +5,9 @@ import time
 logger = logging.getLogger("module-build")
 
 
-def init_logging(cwd, yaml_filename, logger):
-    main_log_file_path = cwd + "/{yaml}-module-build-{timestamp}.log".format(
-        yaml=yaml_filename,
-        timestamp=int(time.time())
-    )
-    log_format = '%(asctime)s | %(levelname)s | %(message)s'
+def init_logging(cwd, yaml_filename, logger, no_stdout):
+    main_log_file_path = cwd + "/{yaml}-module-build-{timestamp}.log".format(yaml=yaml_filename, timestamp=int(time.time()))
+    log_format = "%(asctime)s | %(levelname)s | %(message)s"
 
     logger.setLevel("INFO")
 
@@ -20,8 +17,10 @@ def init_logging(cwd, yaml_filename, logger):
     main_log_handle.setFormatter(log_formatter)
 
     logger.addHandler(main_log_handle)
-    # at the same time we want to write to stdout
-    cli_handler = logging.StreamHandler(sys.stdout)
-    cli_handler.setFormatter(log_formatter)
 
-    logger.addHandler(cli_handler)
+    if not no_stdout:
+        # at the same time we want to write to stdout
+        cli_handler = logging.StreamHandler(sys.stdout)
+        cli_handler.setFormatter(log_formatter)
+
+        logger.addHandler(cli_handler)

--- a/module_build/mock/config.py
+++ b/module_build/mock/config.py
@@ -1,7 +1,13 @@
-from module_build.constants import (KEY_MACROS_PREFIX, KEY_MODULE_ENABLE,
-                                    KEY_MODULE_INSTALL, KEY_SCM_BRANCH,
-                                    KEY_SCM_ENABLE, KEY_SCM_METHOD,
-                                    KEY_SCM_PACKAGE, KEY_SCM_PREFIX_ALL)
+from module_build.constants import (
+    KEY_MACROS_PREFIX,
+    KEY_MODULE_ENABLE,
+    KEY_MODULE_INSTALL,
+    KEY_SCM_BRANCH,
+    KEY_SCM_ENABLE,
+    KEY_SCM_METHOD,
+    KEY_SCM_PACKAGE,
+    KEY_SCM_PREFIX_ALL,
+)
 from module_build.log import logger
 
 
@@ -35,16 +41,18 @@ class MockConfig:
             package (str): Package name
             branch (str): Name of repository branch
         """
-        self.content.update({
-            KEY_SCM_ENABLE: "True",
-            KEY_SCM_METHOD: f"'{method}'",
-            KEY_SCM_PACKAGE: f"'{package}'",
-            KEY_SCM_BRANCH: f"'{branch}'",
-        })
+        self.content.update(
+            {
+                KEY_SCM_ENABLE: "True",
+                KEY_SCM_METHOD: f"'{method}'",
+                KEY_SCM_PACKAGE: f"'{package}'",
+                KEY_SCM_BRANCH: f"'{branch}'",
+            }
+        )
 
     def disable_mbs(self):
         """
-            Removes all MBS keys from mock config.
+        Removes all MBS keys from mock config.
         """
         for k in list(self.content.keys()):
             if k.startswith(KEY_SCM_PREFIX_ALL):
@@ -81,6 +89,6 @@ class MockConfig:
 
             f.write(f"include('{self.base_mock_cfg_path}')")
 
-        logger.info("Mock config for '{component_name}' component written to: {path}")
+        logger.info(f"Mock config for '{component_name}' component written to: {path}")
 
         return path

--- a/tests/builders/test_mock_builder.py
+++ b/tests/builders/test_mock_builder.py
@@ -15,11 +15,12 @@ def test_create_mock_builder(tmpdir):
     """ Test for an instance of MockBuilder. This serves as a sanity test. """
     cwd = tmpdir.mkdir("workdir").strpath
     srpm_dir = None
+    workers = 1
     rootdir = cwd + "/rootdir"
     mock_cfg_path = "/etc/mock/fedora-35-x86_64.cfg"
     external_repos = ["/repo1", "/repo2"]
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
     assert builder.workdir == str(cwd)
     assert builder.mock_cfg_path == mock_cfg_path
@@ -32,11 +33,12 @@ def test_generate_buildbatches(tmpdir):
     sanity test. """
     cwd = tmpdir.mkdir("workdir").strpath
     srpm_dir = None
+    workers = 1
     rootdir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -69,11 +71,12 @@ def test_generate_buildbatches_with_empty_buildorder_property(tmpdir):
     """ Test the generation of build batches when some components are missing buildorders """
     cwd = tmpdir.mkdir("workdir").strpath
     srpm_dir = None
+    workers = 1
     rootdir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
     mmd, version = mock_mmdv3_and_version("modulemd/perl-bootstrap-miss-buildorder.yaml")
 
@@ -100,11 +103,12 @@ def test_generate_buildbatches_with_no_buildorder(tmpdir):
     """ Test the generation of build batches when there is no buildorder set """
     cwd = tmpdir.mkdir("workdir").strpath
     srpm_dir = None
+    workers = 1
     rootdir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
     mmd, version = mock_mmdv3_and_version("modulemd/perl-bootstrap-no-buildorder.yaml")
 
@@ -127,11 +131,12 @@ def test_create_build_contexts(mock_config, tmpdir):
     """
     cwd = tmpdir.mkdir("workdir").strpath
     srpm_dir = None
+    workers = 1
     rootdir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -183,11 +188,12 @@ def test_create_build_context_dir(mock_config, tmpdir):
     """ Test for the creating a `context` dir inside our working directory """
     cwd = tmpdir.mkdir("workdir").strpath
     srpm_dir = None
+    workers = 1
     rootdir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -212,11 +218,12 @@ def test_create_build_context_dir_raises_no_build_context_metadata(tmpdir):
     """
     cwd = tmpdir.mkdir("workdir").strpath
     srpm_dir = None
+    workers = 1
     rootdir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -232,11 +239,12 @@ def test_create_build_batch_dir(mock_config, tmpdir):
     """ Test for the creating a `build_batches` and `batch` directory """
     cwd = tmpdir.mkdir("workdir").strpath
     srpm_dir = None
+    workers = 1
     rootdir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -260,11 +268,12 @@ def test_create_build_batch_dir_raises_no_build_context_metadata(tmpdir):
     """
     cwd = tmpdir.mkdir("workdir")
     srpm_dir = None
+    workers = 1
     rootdir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -284,11 +293,12 @@ def test_build_perl_bootstrap(mock_config, tmpdir):
 
     cwd = tmpdir.mkdir("workdir").strpath
     srpm_dir = None
+    workers = 1
     rootdir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -371,11 +381,12 @@ def test_build_specific_context(mock_config, tmpdir):
 
     cwd = tmpdir.mkdir("workdir").strpath
     srpm_dir = None
+    workers = 1
     rootdir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -414,11 +425,12 @@ def test_build_invalid_context(mock_config, tmpdir):
 
     cwd = tmpdir.mkdir("workdir").strpath
     srpm_dir = None
+    workers = 1
     rootdir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -456,8 +468,9 @@ def test_srpm_build_with_missing_sources(mock_config, srpms, tmpdir, create_fake
     rootdir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
+    workers = 1
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
     mmd, version = mock_mmdv3_and_version(modulemd_path="modulemd/flatpak-runtime.yaml")
     mmd.set_module_name("flatpak-runtime")

--- a/tests/builders/test_mock_builder.py
+++ b/tests/builders/test_mock_builder.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from module_build.builders.mock_builder import MockBuilder
+from module_build.builders.mock_builder import MockBuilder, MockBuildPool
 from module_build.metadata import load_modulemd_file_from_path
 from module_build.stream import ModuleStream
 from tests import (assert_modular_dependencies, fake_buildroot_run,
@@ -11,478 +11,521 @@ from tests import (assert_modular_dependencies, fake_buildroot_run,
                    get_full_data_path, mock_mmdv3_and_version)
 
 
-def test_create_mock_builder(tmpdir):
-    """ Test for an instance of MockBuilder. This serves as a sanity test. """
-    cwd = tmpdir.mkdir("workdir").strpath
-    srpm_dir = None
-    workers = 1
-    rootdir = cwd + "/rootdir"
-    mock_cfg_path = "/etc/mock/fedora-35-x86_64.cfg"
-    external_repos = ["/repo1", "/repo2"]
+# We wrap testcase into classes to avoid duplication
+# of parametrized arguments across multiple test functions
+@pytest.mark.parametrize("workers", (1, 2, 5))
+class TestMockBuilder:
+    def test_create_mock_builder(self, tmpdir, workers):
+        """ Test for an instance of MockBuilder. This serves as a sanity test. """
+        cwd = tmpdir.mkdir("workdir").strpath
+        srpm_dir = None
+        rootdir = cwd + "/rootdir"
+        mock_cfg_path = "/etc/mock/fedora-35-x86_64.cfg"
+        external_repos = ["/repo1", "/repo2"]
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
+        builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
-    assert builder.workdir == str(cwd)
-    assert builder.mock_cfg_path == mock_cfg_path
-    assert builder.external_repos == external_repos
-    assert builder.rootdir == rootdir
+        assert builder.workdir == str(cwd)
+        assert builder.mock_cfg_path == mock_cfg_path
+        assert builder.external_repos == external_repos
+        assert builder.rootdir == rootdir
+
+    def test_generate_buildbatches(self, tmpdir, workers):
+        """ Test the generation of build batches for the build process of a module. This serves as a
+        sanity test. """
+        cwd = tmpdir.mkdir("workdir").strpath
+        srpm_dir = None
+        rootdir = None
+        mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
+        external_repos = []
 
+        builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
-def test_generate_buildbatches(tmpdir):
-    """ Test the generation of build batches for the build process of a module. This serves as a
-    sanity test. """
-    cwd = tmpdir.mkdir("workdir").strpath
-    srpm_dir = None
-    workers = 1
-    rootdir = None
-    mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
-    external_repos = []
+        mmd, version = mock_mmdv3_and_version()
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
+        module_stream = ModuleStream(mmd, version)
 
-    mmd, version = mock_mmdv3_and_version()
+        build_batches = builder.generate_build_batches(module_stream.components)
 
-    module_stream = ModuleStream(mmd, version)
+        assert len(build_batches) == 12
 
-    build_batches = builder.generate_build_batches(module_stream.components)
+        expected_num_comps = 178
+        num_comps = 0
 
-    assert len(build_batches) == 12
+        for b in build_batches:
+            num_comps += len(build_batches[b]["components"])
+            assert "components" in build_batches[b]
+            assert "curr_comp" in build_batches[b]
+            assert build_batches[b]["curr_comp"] == 0
+            assert "curr_comp_state" in build_batches[b]
+            assert "finished_builds" in build_batches[b]
+            assert "batch_state" in build_batches[b]
+            assert "modular_batch_deps" in build_batches[b]
+            assert type(build_batches[b]["modular_batch_deps"]) is list
+            assert build_batches[b]["curr_comp_state"] == "init"
+            assert build_batches[b]["batch_state"] == "init"
+
+        assert expected_num_comps == num_comps
+
+    def test_generate_buildbatches_with_empty_buildorder_property(self, tmpdir, workers):
+        """ Test the generation of build batches when some components are missing buildorders """
+        cwd = tmpdir.mkdir("workdir").strpath
+        srpm_dir = None
+        rootdir = None
+        mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
+        external_repos = []
+
+        builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
+
+        mmd, version = mock_mmdv3_and_version("modulemd/perl-bootstrap-miss-buildorder.yaml")
+
+        module_stream = ModuleStream(mmd, version)
+
+        build_batches = builder.generate_build_batches(module_stream.components)
+
+        assert len(build_batches) == 11
+
+        expected_num_comps = 178
+        num_comps = 0
+        for b in build_batches:
+            num_comps += len(build_batches[b]["components"])
+
+        assert expected_num_comps == num_comps
+        assert len(build_batches[0]["components"]) == 4
+
+        expected_comps = ["perl", "perl-Capture-Tiny", "perl-Test-Output", "perl-generators"]
+        for c in build_batches[0]["components"]:
+            assert c["name"] in expected_comps
+
+    def test_generate_buildbatches_with_no_buildorder(self, tmpdir, workers):
+        """ Test the generation of build batches when there is no buildorder set """
+        cwd = tmpdir.mkdir("workdir").strpath
+        srpm_dir = None
+        rootdir = None
+        mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
+        external_repos = []
+
+        builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
+
+        mmd, version = mock_mmdv3_and_version("modulemd/perl-bootstrap-no-buildorder.yaml")
+
+        module_stream = ModuleStream(mmd, version)
+
+        build_batches = builder.generate_build_batches(module_stream.components)
+
+        assert len(build_batches) == 1
+
+        expected_num_comps = 178
+
+        assert expected_num_comps == len(build_batches[0]["components"])
+
+    @patch("module_build.builders.mock_builder.mockbuild.config.load_config",
+           return_value={"target_arch": "x86_64", "dist": "fc26"})
+    def test_create_build_contexts(self, mock_config, tmpdir, workers):
+        """ Test for creation and initialization of the metadata which will keep track and the state of
+        build process for each context defined in a module stream. This serves as a sanity test.
+        """
+        cwd = tmpdir.mkdir("workdir").strpath
+        srpm_dir = None
+        rootdir = None
+        mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
+        external_repos = []
+
+        builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
+
+        mmd, version = mock_mmdv3_and_version()
+
+        module_stream = ModuleStream(mmd, version)
+
+        builder.create_build_contexts(module_stream)
+
+        assert len(builder.build_contexts) == 2
+
+        expected_context_names = ["f26devel", "f27devel"]
+        expected_nsvca = [
+            "perl-bootstrap:devel:20210925131649:f26devel:x86_64",
+            "perl-bootstrap:devel:20210925131649:f27devel:x86_64",
+        ]
+        expected_modularity_label = [
+            "perl-bootstrap:devel:20210925131649:f26devel",
+            "perl-bootstrap:devel:20210925131649:f27devel",
+        ]
+        expected_rpm_suffixes = [
+            ".module_fc26+f26devel",
+            ".module_fc26+f27devel",
+        ]
+        for c, bc in builder.build_contexts.items():
+            assert "name" in bc
+            assert bc["name"] in expected_context_names
+            assert "nsvca" in bc
+            assert bc["nsvca"] in expected_nsvca
+            assert "metadata" in bc
+            assert "status" in bc
+            assert "state" in bc["status"]
+            assert "current_build_batch" in bc["status"]
+            assert "num_finished_comps" in bc["status"]
+            assert bc["status"]["state"] == "init"
+            assert bc["status"]["current_build_batch"] == 0
+            assert bc["status"]["num_components"] == 178
+            assert "build_batches" in bc
+            assert len(bc["build_batches"]) == 12
+            assert "modularity_label" in bc
+            assert bc["modularity_label"] in expected_modularity_label
+            assert "rpm_macros" in bc
+            assert "modular_deps" in bc
+            assert "rpm_suffix" in bc
+            assert bc["rpm_suffix"] in expected_rpm_suffixes
+
+    @patch("module_build.builders.mock_builder.mockbuild.config.load_config",
+           return_value={"target_arch": "x86_64", "dist": "fc35"})
+    def test_create_build_context_dir(self, mock_config, tmpdir, workers):
+        """ Test for the creating a `context` dir inside our working directory """
+        cwd = tmpdir.mkdir("workdir").strpath
+        srpm_dir = None
+        rootdir = None
+        mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
+        external_repos = []
+
+        builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
+
+        mmd, version = mock_mmdv3_and_version()
+
+        module_stream = ModuleStream(mmd, version)
+
+        context_names = [c.context_name for c in module_stream.contexts]
+
+        builder.create_build_contexts(module_stream)
+
+        expected_dir_names = [context.get_NSVCA() for context in module_stream.contexts]
+
+        for name in context_names:
+            builder.create_build_context_dir(name)
+
+        for name in expected_dir_names:
+            assert name in os.listdir(cwd)
+
+    def test_create_build_context_dir_raises_no_build_context_metadata(self, tmpdir, workers):
+        """ Test the builder to raise when creating a `context` directory when the builder was not
+        initialized correctly.
+        """
+        cwd = tmpdir.mkdir("workdir").strpath
+        srpm_dir = None
+        rootdir = None
+        mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
+        external_repos = []
+
+        builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
+
+        mmd, version = mock_mmdv3_and_version()
+
+        module_stream = ModuleStream(mmd, version)
+
+        with pytest.raises(Exception):
+            builder.create_build_context_dir(module_stream.contexts[0].name)
+
+    @patch("module_build.builders.mock_builder.mockbuild.config.load_config",
+           return_value={"target_arch": "x86_64", "dist": "fc35"})
+    def test_create_build_batch_dir(self, mock_config, tmpdir, workers):
+        """ Test for the creating a `build_batches` and `batch` directory """
+        cwd = tmpdir.mkdir("workdir").strpath
+        srpm_dir = None
+        rootdir = None
+        mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
+        external_repos = []
+
+        builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
+
+        mmd, version = mock_mmdv3_and_version()
+
+        module_stream = ModuleStream(mmd, version)
+
+        context_names = [c.context_name for c in module_stream.contexts]
+
+        builder.create_build_contexts(module_stream)
+
+        builder.create_build_batch_dir(context_names[0], 0)
+
+        build_batches_dir = os.listdir(cwd + "/" + os.listdir(cwd)[0] + "/build_batches")
+
+        assert len(build_batches_dir) == 1
+        assert "batch_0" == build_batches_dir[0]
+
+    def test_create_build_batch_dir_raises_no_build_context_metadata(self, tmpdir, workers):
+        """ Test the builder to raise when creating a `batch` directory when the builder was not
+        initialized correctly.
+        """
+        cwd = tmpdir.mkdir("workdir")
+        srpm_dir = None
+        rootdir = None
+        mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
+        external_repos = []
+
+        builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
+
+        mmd, version = mock_mmdv3_and_version()
+
+        module_stream = ModuleStream(mmd, version)
+
+        with pytest.raises(Exception):
+            builder.create_build_batch_dir(module_stream.contexts[0].name, 0)
+
+    @patch("module_build.builders.mock_builder.MockBuilder.call_createrepo_c_on_dir", new=fake_call_createrepo_c_on_dir)
+    @patch("module_build.builders.mock_builder.MockBuilder.get_artifacts_nevra", new=fake_get_artifacts)
+    @patch("module_build.builders.mock_builder.mockbuild.config.load_config",
+           return_value={"target_arch": "x86_64", "dist": "fc35"})
+    def test_build_perl_bootstrap(self, mock_config, tmpdir, workers):
+        """ This is a sanity test for the build process. We are testing here if everything is created
+        as expected. We will use `fake_buildroot_run` to fake the actual build in a mock buildroot. """
+
+        cwd = tmpdir.mkdir("workdir").strpath
+        srpm_dir = None
+        rootdir = None
+        mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
+        external_repos = []
+
+        builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
+
+        mmd, version = mock_mmdv3_and_version()
+
+        module_stream = ModuleStream(mmd, version)
+
+        with patch("module_build.builders.mock_builder.MockBuildroot.run", new=fake_buildroot_run):
+            builder.build(module_stream, resume=False)
+
+        expected_platform = {
+            "f26devel": "platform:f26",
+            "f27devel": "platform:f27",
+        }
+        for n, c in builder.build_contexts.items():
+            finished_builds_count = 0
+            # if the context dir exists
+            assert os.path.isdir(c["dir"])
+            # if the build_batches dir exists
+            assert os.path.isdir(c["dir"] + "/build_batches")
+
+            for i, b in c["build_batches"].items():
+                # if the current batch dir exists
+                assert os.path.isdir(b["dir"])
+                # if the current batch dir has the correct name
+                assert "batch_{num}".format(num=i) == b["dir"].split("/")[-1]
+
+                for comp in b["components"]:
+                    # if the current component dir exists
+                    comp_dir = b["dir"] + "/{name}".format(name=comp["name"])
+                    assert os.path.isdir(comp_dir)
+                    # if the mock.cfg has been created for the current component
+                    mock_file_path = comp_dir + "/{name}_mock.cfg".format(name=comp["name"])
+                    assert os.path.isfile(mock_file_path)
+                # the last batch does not have a yaml file as there is no other batch that it could
+                # be a modular dependency for
+                if i != 12:
+                    # if the batch yaml file has been correctly created for the current batch
+                    batch_yaml_name_stream = "batch{num}:{num}".format(num=i)
+                    batch_yaml_context = "b{num}".format(num=i)
+                    batch_yaml_file = [f for f in os.listdir(b["dir"]) if f.endswith("yaml")][0]
+                    assert batch_yaml_name_stream in batch_yaml_file
+                    assert batch_yaml_context in batch_yaml_file
+
+                    mmd = load_modulemd_file_from_path(b["dir"] + "/" + batch_yaml_file)
+                    artifacts = mmd.get_rpm_artifacts()
+                    assert len(artifacts) == len(b["finished_builds"])
+
+                    # we check dependencies if they are correct
+                    context_deps = c["modular_deps"]["buildtime"]
+                    batch_deps = b["modular_batch_deps"]
+                    expected_modular_deps = context_deps + batch_deps
+                    modular_deps = mmd.get_dependencies()[0]
+
+                    assert_modular_dependencies(modular_deps, expected_modular_deps)
+
+                # count the finished builds for each batch
+                for f in b["finished_builds"]:
+                    assert os.path.isfile(f)
+
+                finished_builds_count += len(b["finished_builds"])
+            # compare if we have the same number of RPMs in the final repo as we have in their
+            # respective buid batches. This is only a sanity test. Right now 1 component produces 1
+            # RPM file for the sake of the test, in reality one component can produce multiple RPMs.
+            final_rpm_count = len([f for f in os.listdir(c["final_repo_path"]) if f.endswith("rpm")])
+            assert finished_builds_count == final_rpm_count
+
+            # we check the final_repo
+
+            mmd = load_modulemd_file_from_path(c["final_yaml_path"])
+            modular_deps = mmd.get_dependencies()[0]
+            expected_modular_deps = c["modular_deps"]["buildtime"]
+            expected_modular_deps.append(expected_platform[n])
+            assert_modular_dependencies(modular_deps, expected_modular_deps)
+
+    @patch("module_build.builders.mock_builder.MockBuilder.call_createrepo_c_on_dir", new=fake_call_createrepo_c_on_dir)
+    @patch("module_build.builders.mock_builder.MockBuilder.get_artifacts_nevra", new=fake_get_artifacts)
+    @patch("module_build.builders.mock_builder.mockbuild.config.load_config",
+           return_value={"target_arch": "x86_64", "dist": "fc35"})
+    def test_build_specific_context(self, mock_config, tmpdir, workers):
+
+        cwd = tmpdir.mkdir("workdir").strpath
+        srpm_dir = None
+        rootdir = None
+        mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
+        external_repos = []
+
+        builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
+
+        mmd, version = mock_mmdv3_and_version()
+
+        module_stream = ModuleStream(mmd, version)
+
+        context_to_build = "f26devel"
+
+        with patch("module_build.builders.mock_builder.MockBuildroot.run", new=fake_buildroot_run):
+            builder.build(module_stream, resume=False, context_to_build=context_to_build)
+
+        context_dirs = os.listdir(cwd)
+        assert len(context_dirs) == 1
+        assert context_dirs[0] == "perl-bootstrap:devel:20210925131649:f26devel:x86_64"
+
+        # Metadata provided with the modulemd yaml file are processed whole. The builder has always
+        # information about all contexts. During buildtime it chooses which contexts to build, if
+        # specified by the user. That is why there are existing metadata for the `f27devel` context
+        # even it was not choosen for build.
+        # The `f27devel` context only contains metadata provided from the modulemd file. The `f26devel`
+        # context contains also extra metadata added by the build process.
+        f27devel_keys = builder.build_contexts["f27devel"].keys()
+
+        missing_keys = ['dir', 'final_repo_path', 'final_yaml_path']
+
+        for k in missing_keys:
+            assert k not in f27devel_keys
+
+    @patch("module_build.builders.mock_builder.mockbuild.config.load_config",
+           return_value={"target_arch": "x86_64", "dist": "fc35"})
+    def test_build_invalid_context(self, mock_config, tmpdir, workers):
+        """
+        We test to raise an exception when the choosen context does not exist in the provided module
+        stream.
+        """
+
+        cwd = tmpdir.mkdir("workdir").strpath
+        srpm_dir = None
+        rootdir = None
+        mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
+        external_repos = []
+
+        builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
+
+        mmd, version = mock_mmdv3_and_version()
+
+        module_stream = ModuleStream(mmd, version)
+
+        invalid_context_to_build = "invalid_context"
+
+        with pytest.raises(Exception) as e:
+            builder.build(module_stream, resume=False, context_to_build=invalid_context_to_build)
+
+        err_msg = e.value.args[0]
+        assert "does not exist" in err_msg
+        assert "invalid_context" in err_msg
+
+    @pytest.mark.parametrize(
+        "create_fake_srpm",
+        [({"name": "unicorn"}, {"name": "rustc"}), ], indirect=True
+    )
+    @patch("module_build.mock.info.MockBuildInfo.srpms_enabled", return_value=True)
+    @patch("module_build.builders.mock_builder.mockbuild.config.load_config",
+           return_value={"target_arch": "x86_64", "dist": "fc35"})
+    def test_srpm_build_with_missing_sources(self, mock_config, srpms, tmpdir, workers, create_fake_srpm):
+        """
+        Test build in SRPM mode with missing sources.
+        """
+
+        # Validate created Fake SRPMs
+        fake_srpm_files = Path(create_fake_srpm).glob('*.rpm')
+        fake_srpm_files = [x for x in fake_srpm_files if x.is_file()]
+        assert 2 == len(fake_srpm_files)
+
+        cwd = tmpdir.mkdir("workdir").strpath
+        srpm_dir = str(Path(create_fake_srpm).resolve())
+        rootdir = None
+        mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
+        external_repos = []
+
+        builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
+
+        mmd, version = mock_mmdv3_and_version(modulemd_path="modulemd/flatpak-runtime.yaml")
+        mmd.set_module_name("flatpak-runtime")
+        mmd.set_stream_name("devel")
+
+        module_stream = ModuleStream(mmd, version)
+
+        context_to_build = "1234"
+
+        with pytest.raises(Exception) as e:
+            builder.build(module_stream, resume=False, context_to_build=context_to_build)
+
+        err_msg = e.value.args[0]
+        assert "Missing SRPM for" in err_msg
+        assert "flatpak" in err_msg
+
+
+class TestMockBuilderAsync:
+    @patch("module_build.builders.mock_builder.MockBuildPool.add_job")
+    @patch("module_build.builders.mock_builder.MockBuilder.call_createrepo_c_on_dir", new=fake_call_createrepo_c_on_dir)
+    @patch("module_build.builders.mock_builder.MockBuilder.get_artifacts_nevra", new=fake_get_artifacts)
+    @patch("module_build.builders.mock_builder.mockbuild.config.load_config",
+           return_value={"target_arch": "x86_64", "dist": "fc35"})
+    def test_poll_async_add_to_queue(self, mock_config, add_job, tmpdir):
+        """
+            Tests adding jobs to queue
+        """
+        cwd = tmpdir.mkdir("workdir").strpath
+        srpm_dir = None
+        rootdir = None
+        workers = 2
+        mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
+        external_repos = []
+
+        builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
+
+        mmd, version = mock_mmdv3_and_version()
+
+        module_stream = ModuleStream(mmd, version)
+
+        context_to_build = "f26devel"
 
-    expected_num_comps = 178
-    num_comps = 0
-
-    for b in build_batches:
-        num_comps += len(build_batches[b]["components"])
-        assert "components" in build_batches[b]
-        assert "curr_comp" in build_batches[b]
-        assert build_batches[b]["curr_comp"] == 0
-        assert "curr_comp_state" in build_batches[b]
-        assert "finished_builds" in build_batches[b]
-        assert "batch_state" in build_batches[b]
-        assert "modular_batch_deps" in build_batches[b]
-        assert type(build_batches[b]["modular_batch_deps"]) is list
-        assert build_batches[b]["curr_comp_state"] == "init"
-        assert build_batches[b]["batch_state"] == "init"
-
-    assert expected_num_comps == num_comps
-
-
-def test_generate_buildbatches_with_empty_buildorder_property(tmpdir):
-    """ Test the generation of build batches when some components are missing buildorders """
-    cwd = tmpdir.mkdir("workdir").strpath
-    srpm_dir = None
-    workers = 1
-    rootdir = None
-    mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
-    external_repos = []
-
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
-
-    mmd, version = mock_mmdv3_and_version("modulemd/perl-bootstrap-miss-buildorder.yaml")
-
-    module_stream = ModuleStream(mmd, version)
-
-    build_batches = builder.generate_build_batches(module_stream.components)
-
-    assert len(build_batches) == 11
-
-    expected_num_comps = 178
-    num_comps = 0
-    for b in build_batches:
-        num_comps += len(build_batches[b]["components"])
-
-    assert expected_num_comps == num_comps
-    assert len(build_batches[0]["components"]) == 4
-
-    expected_comps = ["perl", "perl-Capture-Tiny", "perl-Test-Output", "perl-generators"]
-    for c in build_batches[0]["components"]:
-        assert c["name"] in expected_comps
-
-
-def test_generate_buildbatches_with_no_buildorder(tmpdir):
-    """ Test the generation of build batches when there is no buildorder set """
-    cwd = tmpdir.mkdir("workdir").strpath
-    srpm_dir = None
-    workers = 1
-    rootdir = None
-    mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
-    external_repos = []
-
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
-
-    mmd, version = mock_mmdv3_and_version("modulemd/perl-bootstrap-no-buildorder.yaml")
-
-    module_stream = ModuleStream(mmd, version)
-
-    build_batches = builder.generate_build_batches(module_stream.components)
-
-    assert len(build_batches) == 1
-
-    expected_num_comps = 178
-
-    assert expected_num_comps == len(build_batches[0]["components"])
-
-
-@patch("module_build.builders.mock_builder.mockbuild.config.load_config",
-       return_value={"target_arch": "x86_64", "dist": "fc26"})
-def test_create_build_contexts(mock_config, tmpdir):
-    """ Test for creation and initialization of the metadata which will keep track and the state of
-    build process for each context defined in a module stream. This serves as a sanity test.
-    """
-    cwd = tmpdir.mkdir("workdir").strpath
-    srpm_dir = None
-    workers = 1
-    rootdir = None
-    mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
-    external_repos = []
-
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
-
-    mmd, version = mock_mmdv3_and_version()
-
-    module_stream = ModuleStream(mmd, version)
-
-    builder.create_build_contexts(module_stream)
-
-    assert len(builder.build_contexts) == 2
-
-    expected_context_names = ["f26devel", "f27devel"]
-    expected_nsvca = [
-        "perl-bootstrap:devel:20210925131649:f26devel:x86_64",
-        "perl-bootstrap:devel:20210925131649:f27devel:x86_64",
-    ]
-    expected_modularity_label = [
-        "perl-bootstrap:devel:20210925131649:f26devel",
-        "perl-bootstrap:devel:20210925131649:f27devel",
-    ]
-    expected_rpm_suffixes = [
-        ".module_fc26+f26devel",
-        ".module_fc26+f27devel",
-    ]
-    for c, bc in builder.build_contexts.items():
-        assert "name" in bc
-        assert bc["name"] in expected_context_names
-        assert "nsvca" in bc
-        assert bc["nsvca"] in expected_nsvca
-        assert "metadata" in bc
-        assert "status" in bc
-        assert "state" in bc["status"]
-        assert "current_build_batch" in bc["status"]
-        assert "num_finished_comps" in bc["status"]
-        assert bc["status"]["state"] == "init"
-        assert bc["status"]["current_build_batch"] == 0
-        assert bc["status"]["num_components"] == 178
-        assert "build_batches" in bc
-        assert len(bc["build_batches"]) == 12
-        assert "modularity_label" in bc
-        assert bc["modularity_label"] in expected_modularity_label
-        assert "rpm_macros" in bc
-        assert "modular_deps" in bc
-        assert "rpm_suffix" in bc
-        assert bc["rpm_suffix"] in expected_rpm_suffixes
-
-
-@patch("module_build.builders.mock_builder.mockbuild.config.load_config",
-       return_value={"target_arch": "x86_64", "dist": "fc35"})
-def test_create_build_context_dir(mock_config, tmpdir):
-    """ Test for the creating a `context` dir inside our working directory """
-    cwd = tmpdir.mkdir("workdir").strpath
-    srpm_dir = None
-    workers = 1
-    rootdir = None
-    mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
-    external_repos = []
-
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
-
-    mmd, version = mock_mmdv3_and_version()
-
-    module_stream = ModuleStream(mmd, version)
-
-    context_names = [c.context_name for c in module_stream.contexts]
-
-    builder.create_build_contexts(module_stream)
-
-    expected_dir_names = [context.get_NSVCA() for context in module_stream.contexts]
-
-    for name in context_names:
-        builder.create_build_context_dir(name)
-
-    for name in expected_dir_names:
-        assert name in os.listdir(cwd)
-
-
-def test_create_build_context_dir_raises_no_build_context_metadata(tmpdir):
-    """ Test the builder to raise when creating a `context` directory when the builder was not
-    initialized correctly.
-    """
-    cwd = tmpdir.mkdir("workdir").strpath
-    srpm_dir = None
-    workers = 1
-    rootdir = None
-    mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
-    external_repos = []
-
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
-
-    mmd, version = mock_mmdv3_and_version()
-
-    module_stream = ModuleStream(mmd, version)
-
-    with pytest.raises(Exception):
-        builder.create_build_context_dir(module_stream.contexts[0].name)
-
-
-@patch("module_build.builders.mock_builder.mockbuild.config.load_config",
-       return_value={"target_arch": "x86_64", "dist": "fc35"})
-def test_create_build_batch_dir(mock_config, tmpdir):
-    """ Test for the creating a `build_batches` and `batch` directory """
-    cwd = tmpdir.mkdir("workdir").strpath
-    srpm_dir = None
-    workers = 1
-    rootdir = None
-    mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
-    external_repos = []
-
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
-
-    mmd, version = mock_mmdv3_and_version()
-
-    module_stream = ModuleStream(mmd, version)
-
-    context_names = [c.context_name for c in module_stream.contexts]
-
-    builder.create_build_contexts(module_stream)
-
-    builder.create_build_batch_dir(context_names[0], 0)
-
-    build_batches_dir = os.listdir(cwd + "/" + os.listdir(cwd)[0] + "/build_batches")
-
-    assert len(build_batches_dir) == 1
-    assert "batch_0" == build_batches_dir[0]
-
-
-def test_create_build_batch_dir_raises_no_build_context_metadata(tmpdir):
-    """ Test the builder to raise when creating a `batch` directory when the builder was not
-    initialized correctly.
-    """
-    cwd = tmpdir.mkdir("workdir")
-    srpm_dir = None
-    workers = 1
-    rootdir = None
-    mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
-    external_repos = []
-
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
-
-    mmd, version = mock_mmdv3_and_version()
-
-    module_stream = ModuleStream(mmd, version)
-
-    with pytest.raises(Exception):
-        builder.create_build_batch_dir(module_stream.contexts[0].name, 0)
-
-
-@patch("module_build.builders.mock_builder.MockBuilder.call_createrepo_c_on_dir", new=fake_call_createrepo_c_on_dir)
-@patch("module_build.builders.mock_builder.MockBuilder.get_artifacts_nevra", new=fake_get_artifacts)
-@patch("module_build.builders.mock_builder.mockbuild.config.load_config",
-       return_value={"target_arch": "x86_64", "dist": "fc35"})
-def test_build_perl_bootstrap(mock_config, tmpdir):
-    """ This is a sanity test for the build process. We are testing here if everything is created
-    as expected. We will use `fake_buildroot_run` to fake the actual build in a mock buildroot. """
-
-    cwd = tmpdir.mkdir("workdir").strpath
-    srpm_dir = None
-    workers = 1
-    rootdir = None
-    mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
-    external_repos = []
-
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
-
-    mmd, version = mock_mmdv3_and_version()
-
-    module_stream = ModuleStream(mmd, version)
-
-    with patch("module_build.builders.mock_builder.MockBuildroot.run", new=fake_buildroot_run):
-        builder.build(module_stream, resume=False)
-
-    expected_platform = {
-        "f26devel": "platform:f26",
-        "f27devel": "platform:f27",
-    }
-    for n, c in builder.build_contexts.items():
-        finished_builds_count = 0
-        # if the context dir exists
-        assert os.path.isdir(c["dir"])
-        # if the build_batches dir exists
-        assert os.path.isdir(c["dir"] + "/build_batches")
-
-        for i, b in c["build_batches"].items():
-            # if the current batch dir exists
-            assert os.path.isdir(b["dir"])
-            # if the current batch dir has the correct name
-            assert "batch_{num}".format(num=i) == b["dir"].split("/")[-1]
-
-            for comp in b["components"]:
-                # if the current component dir exists
-                comp_dir = b["dir"] + "/{name}".format(name=comp["name"])
-                assert os.path.isdir(comp_dir)
-                # if the mock.cfg has been created for the current component
-                mock_file_path = comp_dir + "/{name}_mock.cfg".format(name=comp["name"])
-                assert os.path.isfile(mock_file_path)
-            # the last batch does not have a yaml file as there is no other batch that it could
-            # be a modular dependency for
-            if i != 12:
-                # if the batch yaml file has been correctly created for the current batch
-                batch_yaml_name_stream = "batch{num}:{num}".format(num=i)
-                batch_yaml_context = "b{num}".format(num=i)
-                batch_yaml_file = [f for f in os.listdir(b["dir"]) if f.endswith("yaml")][0]
-                assert batch_yaml_name_stream in batch_yaml_file
-                assert batch_yaml_context in batch_yaml_file
-
-                mmd = load_modulemd_file_from_path(b["dir"] + "/" + batch_yaml_file)
-                artifacts = mmd.get_rpm_artifacts()
-                assert len(artifacts) == len(b["finished_builds"])
-
-                # we check dependencies if they are correct
-                context_deps = c["modular_deps"]["buildtime"]
-                batch_deps = b["modular_batch_deps"]
-                expected_modular_deps = context_deps + batch_deps
-                modular_deps = mmd.get_dependencies()[0]
-
-                assert_modular_dependencies(modular_deps, expected_modular_deps)
-
-            # count the finished builds for each batch
-            for f in b["finished_builds"]:
-                assert os.path.isfile(f)
-
-            finished_builds_count += len(b["finished_builds"])
-        # compare if we have the same number of RPMs in the final repo as we have in their
-        # respective buid batches. This is only a sanity test. Right now 1 component produces 1
-        # RPM file for the sake of the test, in reality one component can produce multiple RPMs.
-        final_rpm_count = len([f for f in os.listdir(c["final_repo_path"]) if f.endswith("rpm")])
-        assert finished_builds_count == final_rpm_count
-
-        # we check the final_repo
-
-        mmd = load_modulemd_file_from_path(c["final_yaml_path"])
-        modular_deps = mmd.get_dependencies()[0]
-        expected_modular_deps = c["modular_deps"]["buildtime"]
-        expected_modular_deps.append(expected_platform[n])
-        assert_modular_dependencies(modular_deps, expected_modular_deps)
-
-
-@patch("module_build.builders.mock_builder.MockBuilder.call_createrepo_c_on_dir", new=fake_call_createrepo_c_on_dir)
-@patch("module_build.builders.mock_builder.MockBuilder.get_artifacts_nevra", new=fake_get_artifacts)
-@patch("module_build.builders.mock_builder.mockbuild.config.load_config",
-       return_value={"target_arch": "x86_64", "dist": "fc35"})
-def test_build_specific_context(mock_config, tmpdir):
-
-    cwd = tmpdir.mkdir("workdir").strpath
-    srpm_dir = None
-    workers = 1
-    rootdir = None
-    mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
-    external_repos = []
-
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
-
-    mmd, version = mock_mmdv3_and_version()
-
-    module_stream = ModuleStream(mmd, version)
-
-    context_to_build = "f26devel"
-
-    with patch("module_build.builders.mock_builder.MockBuildroot.run", new=fake_buildroot_run):
         builder.build(module_stream, resume=False, context_to_build=context_to_build)
 
-    context_dirs = os.listdir(cwd)
-    assert len(context_dirs) == 1
-    assert context_dirs[0] == "perl-bootstrap:devel:20210925131649:f26devel:x86_64"
+        assert add_job.call_count == 178
 
-    # Metadata provided with the modulemd yaml file are processed whole. The builder has always
-    # information about all contexts. During buildtime it chooses which contexts to build, if
-    # specified by the user. That is why there are existing metadata for the `f27devel` context
-    # even it was not choosen for build.
-    # The `f27devel` context only contains metadata provided from the modulemd file. The `f26devel`
-    # context contains also extra metadata added by the build process.
-    f27devel_keys = builder.build_contexts["f27devel"].keys()
+    @patch("module_build.builders.mock_builder.MockBuildPool.add_job", return_value=True)
+    @patch("module_build.builders.mock_builder.MockBuilder.call_createrepo_c_on_dir", new=fake_call_createrepo_c_on_dir)
+    @patch("module_build.builders.mock_builder.MockBuilder.get_artifacts_nevra", new=fake_get_artifacts)
+    @patch("module_build.builders.mock_builder.mockbuild.config.load_config",
+           return_value={"target_arch": "x86_64", "dist": "fc35"})
+    def test_multiprocess_failure(self, mock_config, addjob, tmpdir):
+        """
+            Tests multiprocess component failure
+        """
+        cwd = tmpdir.mkdir("workdir").strpath
+        srpm_dir = None
+        rootdir = None
+        workers = 2
+        mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
+        external_repos = []
 
-    missing_keys = ['dir', 'final_repo_path', 'final_yaml_path']
+        builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
-    for k in missing_keys:
-        assert k not in f27devel_keys
+        mmd, version = mock_mmdv3_and_version(modulemd_path="modulemd/flatpak-runtime.yaml")
+        mmd.set_module_name("flatpak-runtime")
+        mmd.set_stream_name("devel")
 
+        module_stream = ModuleStream(mmd, version)
 
-@patch("module_build.builders.mock_builder.mockbuild.config.load_config",
-       return_value={"target_arch": "x86_64", "dist": "fc35"})
-def test_build_invalid_context(mock_config, tmpdir):
-    """
-    We test to raise an exception when the choosen context does not exist in the provided module
-    stream.
-    """
+        context_to_build = "1234"
 
-    cwd = tmpdir.mkdir("workdir").strpath
-    srpm_dir = None
-    workers = 1
-    rootdir = None
-    mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
-    external_repos = []
+        # Simulate failure by overriding class attribute
+        with patch.object(MockBuildPool, "failed", 1):
+            with pytest.raises(Exception) as e:
+                builder.build(module_stream, resume=False, context_to_build=context_to_build)
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
-
-    mmd, version = mock_mmdv3_and_version()
-
-    module_stream = ModuleStream(mmd, version)
-
-    invalid_context_to_build = "invalid_context"
-
-    with pytest.raises(Exception) as e:
-        builder.build(module_stream, resume=False, context_to_build=invalid_context_to_build)
-
-    err_msg = e.value.args[0]
-    assert "does not exist" in err_msg
-    assert "invalid_context" in err_msg
-
-
-@pytest.mark.parametrize(
-    "create_fake_srpm",
-    [({"name": "unicorn"}, {"name": "rustc"}), ], indirect=True
-)
-@patch("module_build.mock.info.MockBuildInfo.srpms_enabled", return_value=True)
-@patch("module_build.builders.mock_builder.mockbuild.config.load_config",
-       return_value={"target_arch": "x86_64", "dist": "fc35"})
-def test_srpm_build_with_missing_sources(mock_config, srpms, tmpdir, create_fake_srpm):
-    """
-    Test build in SRPM mode with missing sources.
-    """
-
-    # Validate created Fake SRPMs
-    fake_srpm_files = Path(create_fake_srpm).glob('*.rpm')
-    fake_srpm_files = [x for x in fake_srpm_files if x.is_file()]
-    assert 2 == len(fake_srpm_files)
-
-    cwd = tmpdir.mkdir("workdir").strpath
-    srpm_dir = str(Path(create_fake_srpm).resolve())
-    rootdir = None
-    mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
-    external_repos = []
-    workers = 1
-
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
-
-    mmd, version = mock_mmdv3_and_version(modulemd_path="modulemd/flatpak-runtime.yaml")
-    mmd.set_module_name("flatpak-runtime")
-    mmd.set_stream_name("devel")
-
-    module_stream = ModuleStream(mmd, version)
-
-    context_to_build = "1234"
-
-    with pytest.raises(Exception) as e:
-        builder.build(module_stream, resume=False, context_to_build=context_to_build)
-
-    err_msg = e.value.args[0]
-    assert "Missing SRPM for" in err_msg
-    assert "flatpak" in err_msg
+                err_msg = e.value.args[0]
+                assert "Some components failed" in err_msg

--- a/tests/builders/test_resume.py
+++ b/tests/builders/test_resume.py
@@ -3,10 +3,10 @@ import shutil
 from unittest.mock import patch
 
 import pytest
-
 from module_build.builders.mock_builder import MockBuilder
 from module_build.stream import ModuleStream
-from tests import (fake_buildroot_run, fake_call_createrepo_c_on_dir, fake_get_artifacts, get_full_data_path,
+from tests import (fake_buildroot_run, fake_call_createrepo_c_on_dir,
+                   fake_get_artifacts, get_full_data_path,
                    mock_mmdv3_and_version)
 
 
@@ -17,12 +17,13 @@ from tests import (fake_buildroot_run, fake_call_createrepo_c_on_dir, fake_get_a
 def test_resume_module_build_failed_first_component(mock_config, tmpdir):
     """ We test to resume the module build from the first failed component """
     cwd = tmpdir.mkdir("workdir").strpath
+    workers = 1
     rootdir = None
     srpm_dir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -63,7 +64,7 @@ def test_resume_module_build_failed_first_component(mock_config, tmpdir):
     assert "perl-0:1.0-1.module_fc35+f26devel.x86_64.rpm" not in perl_comp_dir
 
     # we run the build again on the same working directory with the resume option on
-    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
     with patch("module_build.builders.mock_builder.MockBuildroot.run",
                new=fake_buildroot_run):
         builder_resumed.build(module_stream, resume=True)
@@ -95,12 +96,13 @@ def test_resume_module_build_failed_first_component(mock_config, tmpdir):
 def test_resume_module_build_failed_not_first_component(mock_config, tmpdir):
     """ We test to resume the module build from a failed component in the 4th batch """
     cwd = tmpdir.mkdir("workdir").strpath
+    workers = 1
     rootdir = None
     srpm_dir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -145,7 +147,7 @@ def test_resume_module_build_failed_not_first_component(mock_config, tmpdir):
     assert "perl-Digest-0:1.0-1.module_fc35+f26devel.x86_64.rpm" not in perl_digest_comp_dir
 
     # we run the build again on the same working directory with the resume option on
-    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
     with patch("module_build.builders.mock_builder.MockBuildroot.run",
                new=fake_buildroot_run):
         builder_resumed.build(module_stream, resume=True)
@@ -178,12 +180,13 @@ def test_resume_module_build_failed_to_create_batch_yaml_file(mock_config, tmpdi
     """ We test to resume the module build on a failed batch closure, where only the yaml file is
     missing """
     cwd = tmpdir.mkdir("workdir").strpath
+    workers = 1
     rootdir = None
     srpm_dir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -225,7 +228,7 @@ def test_resume_module_build_failed_to_create_batch_yaml_file(mock_config, tmpdi
     os.remove(yaml_file_path)
 
     # we run the build again on the same working directory with the resume option on
-    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
     with patch("module_build.builders.mock_builder.MockBuildroot.run",
                new=fake_buildroot_run):
         builder_resumed.build(module_stream, resume=True)
@@ -262,12 +265,13 @@ def test_resume_module_build_failed_to_create_batch_yaml_file(mock_config, tmpdi
 def test_resume_module_build_continue_with_new_batch(mock_config, tmpdir):
     """ We test to resume module build when a new batch directory has failed to create. """
     cwd = tmpdir.mkdir("workdir").strpath
+    workers = 1
     rootdir = None
     srpm_dir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -298,7 +302,7 @@ def test_resume_module_build_continue_with_new_batch(mock_config, tmpdir):
     shutil.rmtree(batch_3_path)
 
     # we run the build again on the same working directory with the resume option on
-    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
     with patch("module_build.builders.mock_builder.MockBuildroot.run",
                new=fake_buildroot_run):
         builder_resumed.build(module_stream, resume=True)
@@ -336,12 +340,13 @@ def test_resume_module_build_continue_with_new_batch(mock_config, tmpdir):
        return_value={"target_arch": "x86_64", "dist": "fc35"})
 def test_resume_module_build_continue_with_next_context(mock_config, tmpdir):
     cwd = tmpdir.mkdir("workdir").strpath
+    workers = 1
     rootdir = None
     srpm_dir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -369,7 +374,7 @@ def test_resume_module_build_continue_with_next_context(mock_config, tmpdir):
     assert "finished" in first_context_dir
 
     # we run the build again on the same working directory with the resume option on
-    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
     with patch("module_build.builders.mock_builder.MockBuildroot.run",
                new=fake_buildroot_run):
         builder_resumed.build(module_stream, resume=True)
@@ -402,12 +407,13 @@ def test_resume_module_build_do_not_continue_with_next_context_when_context_spec
     anything else """
 
     cwd = tmpdir.mkdir("workdir").strpath
+    workers = 1
     rootdir = None
     srpm_dir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -438,7 +444,7 @@ def test_resume_module_build_do_not_continue_with_next_context_when_context_spec
     shutil.rmtree(batch_3_path)
 
     # we run the build again on the same working directory with the resume option on
-    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
     with patch("module_build.builders.mock_builder.MockBuildroot.run",
                new=fake_buildroot_run):
         builder_resumed.build(module_stream, resume=True, context_to_build=context)
@@ -467,12 +473,13 @@ def test_resume_module_build_do_not_continue_with_next_context_when_context_spec
        return_value={"target_arch": "x86_64", "dist": "fc35"})
 def test_resume_module_build_first_specify_context_and_resume_without(mock_config, context, tmpdir):
     cwd = tmpdir.mkdir("workdir").strpath
+    workers = 1
     rootdir = None
     srpm_dir = None
     mock_cfg_path = get_full_data_path("mock_cfg/fedora-35-x86_64.cfg")
     external_repos = []
 
-    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
 
     mmd, version = mock_mmdv3_and_version()
 
@@ -503,7 +510,7 @@ def test_resume_module_build_first_specify_context_and_resume_without(mock_confi
     shutil.rmtree(batch_3_path)
 
     # we run the build again on the same working directory with the resume option on
-    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir)
+    builder_resumed = MockBuilder(mock_cfg_path, cwd, external_repos, rootdir, srpm_dir, workers)
     with patch("module_build.builders.mock_builder.MockBuildroot.run",
                new=fake_buildroot_run):
         builder_resumed.build(module_stream, resume=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,18 @@
+import re
 from subprocess import DEVNULL, run
 from tempfile import NamedTemporaryFile
 
 import pytest
+
+
+# We use parametrize marker to utilize tests for as many scenarios as possible
+# Some scenarios need to be skipped due to async code or something else
+# To avoid duplication we do it here.
+def pytest_collection_modifyitems(config, items):
+    skip = pytest.mark.skip(reason="Skip async testcase scenario ...")
+    for item in items:
+        if re.match(r'.*test_build_(perl_bootstrap|specific_context)\[(?![1])\d\]', item.name):
+            item.add_marker(skip)
 
 
 def create_fake_spec(tmp_srpm_dir, name, version=None, release=None):

--- a/tests/data/modulemd/perl-bootstrap-new.yaml
+++ b/tests/data/modulemd/perl-bootstrap-new.yaml
@@ -1,0 +1,1099 @@
+document: modulemd-packager
+version: 3
+data:
+    stream: '5.34'
+    summary: Perl bootstrap module for bootstrapping Perl module
+    description: >
+        This is the Perl interpreter and a set of modules written in Perl
+        language intended for bootstrapping a perl module. This bootstrap
+        module disables some optional tests to limit the amount of components.
+        This module is not intended for a public use. It's an intermediate
+        step for building the perl module.
+    license: [MIT]
+    xmd:
+        mbs_options:
+            # Prevent from contaminating build root with non-modular Perl packages
+            blocked_packages:
+                - perl
+                - perl-Algorithm-Diff
+                - perl-Archive-Tar
+                - perl-Archive-Zip
+                - perl-autodie
+                - perl-bignum
+                - perl-Capture-Tiny
+                - perl-Carp
+                - perl-Class-Inspector
+                - perl-Compress-Bzip2
+                - perl-Compress-Raw-Bzip2
+                - perl-Compress-Raw-Lzma
+                - perl-Compress-Raw-Zlib
+                - perl-Config-AutoConf
+                - perl-Config-Perl-V
+                - perl-constant
+                - perl-CPAN
+                - perl-CPAN-DistnameInfo
+                - perl-CPAN-Meta
+                - perl-CPAN-Meta-Requirements
+                - perl-CPAN-Meta-YAML
+                - perl-Data-Dumper
+                - perl-Data-OptList
+                - perl-Data-Section
+                - perl-DB_File
+                - perl-Devel-PPPort
+                - perl-Devel-Size
+                - perl-Digest
+                - perl-Digest-MD5
+                - perl-Digest-SHA
+                - perl-Digest-SHA1
+                - perl-Encode
+                - perl-Encode-Locale
+                - perl-Env
+                - perl-experimental
+                - perl-Exporter
+                - perl-ExtUtils-CBuilder
+                - perl-ExtUtils-Config
+                - perl-ExtUtils-Helpers
+                - perl-ExtUtils-Install
+                - perl-ExtUtils-InstallPaths
+                - perl-ExtUtils-MakeMaker
+                - perl-ExtUtils-Manifest
+                - perl-ExtUtils-ParseXS
+                - perl-Fedora-VSP
+                - perl-File-Fetch
+                - perl-File-HomeDir
+                - perl-File-Path
+                - perl-File-Remove
+                - perl-File-ShareDir
+                - perl-File-ShareDir-Install
+                - perl-File-Temp
+                - perl-File-Which
+                - perl-Filter
+                - perl-Filter-Simple
+                - perl-generators
+                - perl-Getopt-Long
+                - perl-HTTP-Tiny
+                - perl-Importer
+                - perl-inc-latest
+                - perl-IO-Compress
+                - perl-IO-Compress-Lzma
+                - perl-IO-Socket-IP
+                - perl-IO-Tty
+                - perl-IO-Zlib
+                - perl-IPC-Cmd
+                - perl-IPC-Run
+                - perl-IPC-System-Simple
+                - perl-IPC-SysV
+                - perl-JSON-PP
+                - perl-libnet
+                - perl-local-lib
+                - perl-Locale-Maketext
+                - perl-Math-BigInt
+                - perl-Math-BigInt-FastCalc
+                - perl-Math-BigInt-GMP
+                - perl-Math-BigRat
+                - perl-MIME-Base64
+                - perl-Module-Build
+                - perl-Module-Build-Tiny
+                - perl-Module-CoreList
+                - perl-Module-Install
+                - perl-Module-Install-AuthorTests
+                - perl-Module-Install-ExtraTests
+                - perl-Module-Load
+                - perl-Module-Load-Conditional
+                - perl-Module-Metadata
+                - perl-Module-ScanDeps
+                - perl-Module-Signature
+                - perl-MRO-Compat
+                - perl-Net-Ping
+                - perl-Object-HashBase
+                - perl-Package-Generator
+                - perl-Params-Check
+                - perl-Params-Util
+                - perl-parent
+                - perl-PathTools
+                - perl-Perl-OSType
+                - perl-perlfaq
+                - perl-PerlIO-via-QuotedPrint
+                - perl-Pod-Checker
+                - perl-Pod-Escapes
+                - perl-Pod-Parser
+                - perl-Pod-Perldoc
+                - perl-Pod-Simple
+                - perl-Pod-Usage
+                - perl-podlators
+                - perl-Readonly
+                - perl-Scalar-List-Utils
+                - perl-Socket
+                - perl-Software-License
+                - perl-srpm-macros
+                - perl-Storable
+                - perl-Sub-Exporter
+                - perl-Sub-Install
+                - perl-Sys-Syslog
+                - perl-Term-ANSIColor
+                - perl-Term-Cap
+                - perl-Term-Size-Any
+                - perl-Term-Size-Perl
+                - perl-Term-Table
+                - perl-TermReadKey
+                - perl-Test-FailWarnings
+                - perl-Test-Harness
+                - perl-Test-Needs
+                - perl-Test-NoWarnings
+                - perl-Test-Pod
+                - perl-Test-Requires
+                - perl-Test-Simple
+                - perl-Text-Balanced
+                - perl-Text-Diff
+                - perl-Text-Glob
+                - perl-Text-ParseWords
+                - perl-Text-Tabs+Wrap
+                - perl-Text-Template
+                - perl-Thread-Queue
+                - perl-threads
+                - perl-threads-shared
+                - perl-Tie-RefHash
+                - perl-Time-HiRes
+                - perl-Time-Local
+                - perl-Try-Tiny
+                - perl-Unicode-Collate
+                - perl-Unicode-Normalize
+                - perl-URI
+                - perl-version
+                - perl-YAML-Tiny
+    configurations:
+        - context: 'f34'
+          platform: f34
+          buildopts:
+              rpms:
+                  macros: |
+                      %perl_bootstrap 1
+                      %_with_perl_enables_groff 1
+                      %_without_perl_enables_syslog_test 1
+                      %_with_perl_enables_systemtap 1
+                      %_without_perl_enables_tcsh 1
+                      %_without_perl_Archive_Tar_enables_optional_test 1
+                      %_without_perl_autodie_enables_optional_test 1
+                      %_without_perl_Compress_Bzip2_enables_optional_test 1
+                      %_without_perl_Compress_Raw_Bzip2_enables_optional_test 1
+                      %_without_perl_Compress_Raw_Lzma_enables_optional_test 1
+                      %_without_perl_Compress_Raw_Zlib_enables_optional_test 1
+                      %_without_perl_Config_AutoConf_enables_File_Slurper 1
+                      %_without_perl_Config_AutoConf_enables_Scalar_Util 1
+                      %_without_perl_constant_enables_optional_test 1
+                      %_without_perl_CPAN_enables_optional_test 1
+                      %_without_perl_CPAN_Meta_Requirements_enables_optional_test 1
+                      %_without_perl_CPAN_Meta_YAML_enables_extra_test 1
+                      %_without_perl_Data_OptList_enables_extra_test 1
+                      %_without_perl_Data_Section_enables_extra_test 1
+                      %_without_perl_Data_Section_enables_optional_test 1
+                      %_without_perl_DB_File_enables_optional_test 1
+                      %_without_perl_Devel_PPPort_enables_optional_test 1
+                      %_without_perl_Devel_Size_enables_optional_test 1
+                      %_without_perl_Digest_SHA_enables_optional_test 1
+                      %_without_perl_Exporter_enables_optional_test 1
+                      %_without_perl_ExtUtils_Install_enables_optional_test 1
+                      %_without_perl_File_ShareDir_enables_optional_deps 1
+                      %_without_perl_Filter_enables_optional_test 1
+                      %_without_perl_IO_Compress_enables_optional_test 1
+                      %_without_perl_IO_Compress_Lzma_enables_optional_test 1
+                      %_without_perl_IO_Socket_IP_enables_optional_test 1
+                      %_without_perl_IPC_Cmd_enables_IPC_Run 1
+                      %_without_perl_IPC_System_Simple_enables_optional_test 1
+                      %_without_perl_IPC_SysV_enables_optional_test 1
+                      %_without_perl_JSON_PP_enables_optional_test 1
+                      %_without_perl_libnet_enables_ssl 1
+                      %_without_perl_Locale_Maketext_enables_optional_test 1
+                      %_without_perl_Module_Build_enables_optional_test 1
+                      %_without_perl_Module_CoreList_enables_optional_test 1
+                      %_without_perl_Module_Runtime_enables_optional_test 1
+                      %_without_perl_Module_ScanDeps_enables_optional_tests 1
+                      %_without_perl_Net_Ping_enables_optional_test 1
+                      %_without_perl_Package_Generator_enables_extra_test 1
+                      %_without_perl_Perl_OSType_enables_optional_test 1
+                      %_without_perl_Pod_Parser_enables_optional_test 1
+                      %_without_perl_Pod_Perldoc_enables_tk_test 1
+                      %_without_perl_Pod_Simple_enables_optional_test 1
+                      %_without_perl_Software_License_enables_extra_test 1
+                      %_without_perl_Software_License_enables_optional_test 1
+                      %_without_perl_Sub_Exporter_enables_extra_test 1
+                      %_without_perl_Sub_Install_enables_optional_test 1
+                      %_without_perl_Sys_Syslog_enables_optional_test 1
+                      %_without_perl_Term_Size_Any_enabels_optional_test 1
+                      %_with_perl_Term_Table_enables_terminal 1
+                      %_without_perl_Term_Table_enables_unicode 1
+                      %_without_perl_Test_Harness_enables_optional_test 1
+                      %_without_perl_Test_NoWarnings_enables_stack_trace 1
+                      %_without_perl_Test_Simple_enables_Module_Pluggable 1
+                      %_without_perl_Test_Simple_enables_optional_test 1
+                      %_without_perl_Text_Template_enables_optional_test 1
+                      %_without_perl_Try_Tiny_enables_optional_test 1
+                      %_without_perl_URI_enables_Business_ISBN 1
+                      %_without_perl_version_enables_optional_test 1
+                      %_without_perl_YAML_Tiny_enables_JSON_MaybeX_test 1
+        - context: 'f35'
+          platform: f35
+          buildopts:
+              rpms:
+                  macros: |
+                      %perl_bootstrap 1
+                      %_with_perl_enables_groff 1
+                      %_without_perl_enables_syslog_test 1
+                      %_with_perl_enables_systemtap 1
+                      %_without_perl_enables_tcsh 1
+                      %_without_perl_Archive_Tar_enables_optional_test 1
+                      %_without_perl_autodie_enables_optional_test 1
+                      %_without_perl_Compress_Bzip2_enables_optional_test 1
+                      %_without_perl_Compress_Raw_Bzip2_enables_optional_test 1
+                      %_without_perl_Compress_Raw_Lzma_enables_optional_test 1
+                      %_without_perl_Compress_Raw_Zlib_enables_optional_test 1
+                      %_without_perl_Config_AutoConf_enables_File_Slurper 1
+                      %_without_perl_Config_AutoConf_enables_Scalar_Util 1
+                      %_without_perl_constant_enables_optional_test 1
+                      %_without_perl_CPAN_enables_optional_test 1
+                      %_without_perl_CPAN_Meta_Requirements_enables_optional_test 1
+                      %_without_perl_CPAN_Meta_YAML_enables_extra_test 1
+                      %_without_perl_Data_OptList_enables_extra_test 1
+                      %_without_perl_Data_Section_enables_extra_test 1
+                      %_without_perl_Data_Section_enables_optional_test 1
+                      %_without_perl_DB_File_enables_optional_test 1
+                      %_without_perl_Devel_PPPort_enables_optional_test 1
+                      %_without_perl_Devel_Size_enables_optional_test 1
+                      %_without_perl_Digest_SHA_enables_optional_test 1
+                      %_without_perl_Exporter_enables_optional_test 1
+                      %_without_perl_ExtUtils_Install_enables_optional_test 1
+                      %_without_perl_File_ShareDir_enables_optional_deps 1
+                      %_without_perl_Filter_enables_optional_test 1
+                      %_without_perl_IO_Compress_enables_optional_test 1
+                      %_without_perl_IO_Compress_Lzma_enables_optional_test 1
+                      %_without_perl_IO_Socket_IP_enables_optional_test 1
+                      %_without_perl_IPC_Cmd_enables_IPC_Run 1
+                      %_without_perl_IPC_System_Simple_enables_optional_test 1
+                      %_without_perl_IPC_SysV_enables_optional_test 1
+                      %_without_perl_JSON_PP_enables_optional_test 1
+                      %_without_perl_libnet_enables_ssl 1
+                      %_without_perl_Locale_Maketext_enables_optional_test 1
+                      %_without_perl_Module_Build_enables_optional_test 1
+                      %_without_perl_Module_CoreList_enables_optional_test 1
+                      %_without_perl_Module_Runtime_enables_optional_test 1
+                      %_without_perl_Module_ScanDeps_enables_optional_tests 1
+                      %_without_perl_Net_Ping_enables_optional_test 1
+                      %_without_perl_Package_Generator_enables_extra_test 1
+                      %_without_perl_Perl_OSType_enables_optional_test 1
+                      %_without_perl_Pod_Parser_enables_optional_test 1
+                      %_without_perl_Pod_Perldoc_enables_tk_test 1
+                      %_without_perl_Pod_Simple_enables_optional_test 1
+                      %_without_perl_Software_License_enables_extra_test 1
+                      %_without_perl_Software_License_enables_optional_test 1
+                      %_without_perl_Sub_Exporter_enables_extra_test 1
+                      %_without_perl_Sub_Install_enables_optional_test 1
+                      %_without_perl_Sys_Syslog_enables_optional_test 1
+                      %_without_perl_Term_Size_Any_enabels_optional_test 1
+                      %_with_perl_Term_Table_enables_terminal 1
+                      %_without_perl_Term_Table_enables_unicode 1
+                      %_without_perl_Test_Harness_enables_optional_test 1
+                      %_without_perl_Test_NoWarnings_enables_stack_trace 1
+                      %_without_perl_Test_Simple_enables_Module_Pluggable 1
+                      %_without_perl_Test_Simple_enables_optional_test 1
+                      %_without_perl_Text_Template_enables_optional_test 1
+                      %_without_perl_Try_Tiny_enables_optional_test 1
+                      %_without_perl_URI_enables_Business_ISBN 1
+                      %_without_perl_version_enables_optional_test 1
+                      %_without_perl_YAML_Tiny_enables_JSON_MaybeX_test 1
+        - context: 'f36'
+          platform: f36
+          buildopts:
+              rpms:
+                  macros: |
+                      %perl_bootstrap 1
+                      %_with_perl_enables_groff 1
+                      %_without_perl_enables_syslog_test 1
+                      %_with_perl_enables_systemtap 1
+                      %_without_perl_enables_tcsh 1
+                      %_without_perl_Archive_Tar_enables_optional_test 1
+                      %_without_perl_autodie_enables_optional_test 1
+                      %_without_perl_Compress_Bzip2_enables_optional_test 1
+                      %_without_perl_Compress_Raw_Bzip2_enables_optional_test 1
+                      %_without_perl_Compress_Raw_Lzma_enables_optional_test 1
+                      %_without_perl_Compress_Raw_Zlib_enables_optional_test 1
+                      %_without_perl_Config_AutoConf_enables_File_Slurper 1
+                      %_without_perl_Config_AutoConf_enables_Scalar_Util 1
+                      %_without_perl_constant_enables_optional_test 1
+                      %_without_perl_CPAN_enables_optional_test 1
+                      %_without_perl_CPAN_Meta_Requirements_enables_optional_test 1
+                      %_without_perl_CPAN_Meta_YAML_enables_extra_test 1
+                      %_without_perl_Data_OptList_enables_extra_test 1
+                      %_without_perl_Data_Section_enables_extra_test 1
+                      %_without_perl_Data_Section_enables_optional_test 1
+                      %_without_perl_DB_File_enables_optional_test 1
+                      %_without_perl_Devel_PPPort_enables_optional_test 1
+                      %_without_perl_Devel_Size_enables_optional_test 1
+                      %_without_perl_Digest_SHA_enables_optional_test 1
+                      %_without_perl_Exporter_enables_optional_test 1
+                      %_without_perl_ExtUtils_Install_enables_optional_test 1
+                      %_without_perl_File_ShareDir_enables_optional_deps 1
+                      %_without_perl_Filter_enables_optional_test 1
+                      %_without_perl_IO_Compress_enables_optional_test 1
+                      %_without_perl_IO_Compress_Lzma_enables_optional_test 1
+                      %_without_perl_IO_Socket_IP_enables_optional_test 1
+                      %_without_perl_IPC_Cmd_enables_IPC_Run 1
+                      %_without_perl_IPC_System_Simple_enables_optional_test 1
+                      %_without_perl_IPC_SysV_enables_optional_test 1
+                      %_without_perl_JSON_PP_enables_optional_test 1
+                      %_without_perl_libnet_enables_ssl 1
+                      %_without_perl_Locale_Maketext_enables_optional_test 1
+                      %_without_perl_Module_Build_enables_optional_test 1
+                      %_without_perl_Module_CoreList_enables_optional_test 1
+                      %_without_perl_Module_Runtime_enables_optional_test 1
+                      %_without_perl_Module_ScanDeps_enables_optional_tests 1
+                      %_without_perl_Net_Ping_enables_optional_test 1
+                      %_without_perl_Package_Generator_enables_extra_test 1
+                      %_without_perl_Perl_OSType_enables_optional_test 1
+                      %_without_perl_Pod_Parser_enables_optional_test 1
+                      %_without_perl_Pod_Perldoc_enables_tk_test 1
+                      %_without_perl_Pod_Simple_enables_optional_test 1
+                      %_without_perl_Software_License_enables_extra_test 1
+                      %_without_perl_Software_License_enables_optional_test 1
+                      %_without_perl_Sub_Exporter_enables_extra_test 1
+                      %_without_perl_Sub_Install_enables_optional_test 1
+                      %_without_perl_Sys_Syslog_enables_optional_test 1
+                      %_without_perl_Term_Size_Any_enabels_optional_test 1
+                      %_with_perl_Term_Table_enables_terminal 1
+                      %_without_perl_Term_Table_enables_unicode 1
+                      %_without_perl_Test_Harness_enables_optional_test 1
+                      %_without_perl_Test_NoWarnings_enables_stack_trace 1
+                      %_without_perl_Test_Simple_enables_Module_Pluggable 1
+                      %_without_perl_Test_Simple_enables_optional_test 1
+                      %_without_perl_Text_Template_enables_optional_test 1
+                      %_without_perl_Try_Tiny_enables_optional_test 1
+                      %_without_perl_URI_enables_Business_ISBN 1
+                      %_without_perl_version_enables_optional_test 1
+                      %_without_perl_YAML_Tiny_enables_JSON_MaybeX_test 1
+        - context: 'f37'
+          platform: f37
+          buildopts:
+              rpms:
+                  macros: |
+                      %perl_bootstrap 1
+                      %_with_perl_enables_groff 1
+                      %_without_perl_enables_syslog_test 1
+                      %_with_perl_enables_systemtap 1
+                      %_without_perl_enables_tcsh 1
+                      %_without_perl_Archive_Tar_enables_optional_test 1
+                      %_without_perl_autodie_enables_optional_test 1
+                      %_without_perl_Compress_Bzip2_enables_optional_test 1
+                      %_without_perl_Compress_Raw_Bzip2_enables_optional_test 1
+                      %_without_perl_Compress_Raw_Lzma_enables_optional_test 1
+                      %_without_perl_Compress_Raw_Zlib_enables_optional_test 1
+                      %_without_perl_Config_AutoConf_enables_File_Slurper 1
+                      %_without_perl_Config_AutoConf_enables_Scalar_Util 1
+                      %_without_perl_constant_enables_optional_test 1
+                      %_without_perl_CPAN_enables_optional_test 1
+                      %_without_perl_CPAN_Meta_Requirements_enables_optional_test 1
+                      %_without_perl_CPAN_Meta_YAML_enables_extra_test 1
+                      %_without_perl_Data_OptList_enables_extra_test 1
+                      %_without_perl_Data_Section_enables_extra_test 1
+                      %_without_perl_Data_Section_enables_optional_test 1
+                      %_without_perl_DB_File_enables_optional_test 1
+                      %_without_perl_Devel_PPPort_enables_optional_test 1
+                      %_without_perl_Devel_Size_enables_optional_test 1
+                      %_without_perl_Digest_SHA_enables_optional_test 1
+                      %_without_perl_Exporter_enables_optional_test 1
+                      %_without_perl_ExtUtils_Install_enables_optional_test 1
+                      %_without_perl_File_ShareDir_enables_optional_deps 1
+                      %_without_perl_Filter_enables_optional_test 1
+                      %_without_perl_IO_Compress_enables_optional_test 1
+                      %_without_perl_IO_Compress_Lzma_enables_optional_test 1
+                      %_without_perl_IO_Socket_IP_enables_optional_test 1
+                      %_without_perl_IPC_Cmd_enables_IPC_Run 1
+                      %_without_perl_IPC_System_Simple_enables_optional_test 1
+                      %_without_perl_IPC_SysV_enables_optional_test 1
+                      %_without_perl_JSON_PP_enables_optional_test 1
+                      %_without_perl_libnet_enables_ssl 1
+                      %_without_perl_Locale_Maketext_enables_optional_test 1
+                      %_without_perl_Module_Build_enables_optional_test 1
+                      %_without_perl_Module_CoreList_enables_optional_test 1
+                      %_without_perl_Module_Runtime_enables_optional_test 1
+                      %_without_perl_Module_ScanDeps_enables_optional_tests 1
+                      %_without_perl_Net_Ping_enables_optional_test 1
+                      %_without_perl_Package_Generator_enables_extra_test 1
+                      %_without_perl_Perl_OSType_enables_optional_test 1
+                      %_without_perl_Pod_Parser_enables_optional_test 1
+                      %_without_perl_Pod_Perldoc_enables_tk_test 1
+                      %_without_perl_Pod_Simple_enables_optional_test 1
+                      %_without_perl_Software_License_enables_extra_test 1
+                      %_without_perl_Software_License_enables_optional_test 1
+                      %_without_perl_Sub_Exporter_enables_extra_test 1
+                      %_without_perl_Sub_Install_enables_optional_test 1
+                      %_without_perl_Sys_Syslog_enables_optional_test 1
+                      %_without_perl_Term_Size_Any_enabels_optional_test 1
+                      %_with_perl_Term_Table_enables_terminal 1
+                      %_without_perl_Term_Table_enables_unicode 1
+                      %_without_perl_Test_Harness_enables_optional_test 1
+                      %_without_perl_Test_NoWarnings_enables_stack_trace 1
+                      %_without_perl_Test_Simple_enables_Module_Pluggable 1
+                      %_without_perl_Test_Simple_enables_optional_test 1
+                      %_without_perl_Text_Template_enables_optional_test 1
+                      %_without_perl_Try_Tiny_enables_optional_test 1
+                      %_without_perl_URI_enables_Business_ISBN 1
+                      %_without_perl_version_enables_optional_test 1
+                      %_without_perl_YAML_Tiny_enables_JSON_MaybeX_test 1
+        - context: 'eln'
+          platform: eln
+          buildopts:
+              rpms:
+                  macros: |
+                      %perl_bootstrap 1
+                      %_with_perl_enables_groff 1
+                      %_without_perl_enables_syslog_test 1
+                      %_with_perl_enables_systemtap 1
+                      %_without_perl_enables_tcsh 1
+                      %_without_perl_Archive_Tar_enables_optional_test 1
+                      %_without_perl_autodie_enables_optional_test 1
+                      %_without_perl_Compress_Bzip2_enables_optional_test 1
+                      %_without_perl_Compress_Raw_Bzip2_enables_optional_test 1
+                      %_without_perl_Compress_Raw_Lzma_enables_optional_test 1
+                      %_without_perl_Compress_Raw_Zlib_enables_optional_test 1
+                      %_without_perl_Config_AutoConf_enables_File_Slurper 1
+                      %_without_perl_Config_AutoConf_enables_Scalar_Util 1
+                      %_without_perl_constant_enables_optional_test 1
+                      %_without_perl_CPAN_enables_optional_test 1
+                      %_without_perl_CPAN_Meta_Requirements_enables_optional_test 1
+                      %_without_perl_CPAN_Meta_YAML_enables_extra_test 1
+                      %_without_perl_Data_OptList_enables_extra_test 1
+                      %_without_perl_Data_Section_enables_extra_test 1
+                      %_without_perl_Data_Section_enables_optional_test 1
+                      %_without_perl_DB_File_enables_optional_test 1
+                      %_without_perl_Devel_PPPort_enables_optional_test 1
+                      %_without_perl_Devel_Size_enables_optional_test 1
+                      %_without_perl_Digest_SHA_enables_optional_test 1
+                      %_without_perl_Exporter_enables_optional_test 1
+                      %_without_perl_ExtUtils_Install_enables_optional_test 1
+                      %_without_perl_File_ShareDir_enables_optional_deps 1
+                      %_without_perl_Filter_enables_optional_test 1
+                      %_without_perl_IO_Compress_enables_optional_test 1
+                      %_without_perl_IO_Compress_Lzma_enables_optional_test 1
+                      %_without_perl_IO_Socket_IP_enables_optional_test 1
+                      %_without_perl_IPC_Cmd_enables_IPC_Run 1
+                      %_without_perl_IPC_System_Simple_enables_optional_test 1
+                      %_without_perl_IPC_SysV_enables_optional_test 1
+                      %_without_perl_JSON_PP_enables_optional_test 1
+                      %_without_perl_libnet_enables_ssl 1
+                      %_without_perl_Locale_Maketext_enables_optional_test 1
+                      %_without_perl_Module_Build_enables_optional_test 1
+                      %_without_perl_Module_CoreList_enables_optional_test 1
+                      %_without_perl_Module_Runtime_enables_optional_test 1
+                      %_without_perl_Module_ScanDeps_enables_optional_tests 1
+                      %_without_perl_Net_Ping_enables_optional_test 1
+                      %_without_perl_Package_Generator_enables_extra_test 1
+                      %_without_perl_Perl_OSType_enables_optional_test 1
+                      %_without_perl_Pod_Parser_enables_optional_test 1
+                      %_without_perl_Pod_Perldoc_enables_tk_test 1
+                      %_without_perl_Pod_Simple_enables_optional_test 1
+                      %_without_perl_Software_License_enables_extra_test 1
+                      %_without_perl_Software_License_enables_optional_test 1
+                      %_without_perl_Sub_Exporter_enables_extra_test 1
+                      %_without_perl_Sub_Install_enables_optional_test 1
+                      %_without_perl_Sys_Syslog_enables_optional_test 1
+                      %_without_perl_Term_Size_Any_enabels_optional_test 1
+                      %_with_perl_Term_Table_enables_terminal 1
+                      %_without_perl_Term_Table_enables_unicode 1
+                      %_without_perl_Test_Harness_enables_optional_test 1
+                      %_without_perl_Test_NoWarnings_enables_stack_trace 1
+                      %_without_perl_Test_Simple_enables_Module_Pluggable 1
+                      %_without_perl_Test_Simple_enables_optional_test 1
+                      %_without_perl_Text_Template_enables_optional_test 1
+                      %_without_perl_Try_Tiny_enables_optional_test 1
+                      %_without_perl_URI_enables_Business_ISBN 1
+                      %_without_perl_version_enables_optional_test 1
+                      %_without_perl_YAML_Tiny_enables_JSON_MaybeX_test 1
+    references:
+        community: https://docs.fedoraproject.org/en-US/modularity/
+        documentation: https://asamalik.fedorapeople.org/boltron-doc/development/building-modules/module-guidelines.html
+        tracker: https://bugzilla.redhat.com/buglist.cgi?classification=Fedora&product=Fedora%20Modules&component=perl-bootstrap
+    components:
+        rpms:
+            perl:
+                rationale: The Perl interpreter.
+                ref: f36
+                buildorder: 0
+            perl-Fedora-VSP:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 1
+            perl-generators:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 2
+            perl-Algorithm-Diff:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Archive-Tar:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Archive-Zip:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-autodie:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Capture-Tiny:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Carp:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Class-Inspector:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Compress-Bzip2:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Compress-Raw-Bzip2:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Compress-Raw-Lzma:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Compress-Raw-Zlib:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Config-Perl-V:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-constant:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-CPAN-DistnameInfo:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-CPAN-Meta:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-CPAN-Meta-Requirements:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-CPAN-Meta-YAML:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Data-Dumper:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-DB_File:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Devel-PPPort:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Devel-Size:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Digest:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Digest-MD5:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Digest-SHA:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Digest-SHA1:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Encode:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Encode-Locale:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Env:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-experimental:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Exporter:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-ExtUtils-CBuilder:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-ExtUtils-Config:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-ExtUtils-Helpers:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-ExtUtils-Install:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-ExtUtils-MakeMaker:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-ExtUtils-Manifest:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-ExtUtils-ParseXS:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-File-Fetch:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-File-Path:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-File-Remove:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-File-ShareDir-Install:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-File-Temp:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-File-Which:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Filter:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Filter-Simple:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Getopt-Long:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-HTTP-Tiny:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Importer:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-inc-latest:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-IO-Socket-IP:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-IO-Tty:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-IO-Zlib:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-IPC-Cmd:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-IPC-System-Simple:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-IPC-SysV:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-JSON-PP:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-libnet:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Locale-Maketext:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Math-BigInt:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-MIME-Base64:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Module-CoreList:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Module-Install-ExtraTests:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Module-Load:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Module-Load-Conditional:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Module-Metadata:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-MRO-Compat:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Net-Ping:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Object-HashBase:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Params-Check:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-parent:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-PathTools:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-perlfaq:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-PerlIO-via-QuotedPrint:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Perl-OSType:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Pod-Escapes:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Pod-Checker:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-podlators:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Pod-Parser:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Pod-Perldoc:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Pod-Simple:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Scalar-List-Utils:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Socket:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Storable:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Sub-Install:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Sys-Syslog:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Term-ANSIColor:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Term-Cap:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-TermReadKey:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Term-Size-Perl:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Test-Harness:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Test-Needs:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Test-NoWarnings:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Test-Pod:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Test-Requires:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Test-Simple:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Text-Balanced:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Text-Glob:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Text-ParseWords:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Text-Tabs+Wrap:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Text-Template:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Thread-Queue:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-threads:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-threads-shared:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Tie-RefHash:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Time-HiRes:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Time-Local:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Try-Tiny:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Unicode-Collate:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Unicode-Normalize:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-version:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-YAML-Tiny:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 3
+            perl-Config-AutoConf:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 4
+            perl-CPAN:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 4
+            perl-ExtUtils-InstallPaths:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 4
+            perl-File-HomeDir:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 4
+            perl-File-ShareDir:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 4
+            perl-IO-Compress:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 4
+            perl-Math-BigInt-FastCalc:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 4
+            perl-Math-BigInt-GMP:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 4
+            perl-Math-BigRat:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 4
+            perl-Module-Build:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 4
+            perl-Module-ScanDeps:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 4
+            perl-Pod-Usage:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 4
+            perl-Term-Size-Any:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 4
+            perl-Test-FailWarnings:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 4
+            perl-Text-Diff:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 4
+            perl-URI:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 4
+            perl-bignum:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 5
+            perl-IO-Compress-Lzma:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 5
+            perl-local-lib:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 5
+            perl-Module-Build-Tiny:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 5
+            perl-Module-Install:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 5
+            perl-Params-Util:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 5
+            perl-Term-Table:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 5
+            perl-Data-OptList:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 6
+            perl-Module-Install-AuthorTests:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 6
+            perl-Package-Generator:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 6
+            perl-Readonly:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 6
+            perl-IPC-Run:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 7
+            perl-Sub-Exporter:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 7
+            perl-Data-Section:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 8
+            perl-Module-Signature:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 8
+            perl-Software-License:
+                rationale: A build dependency.
+                ref: f36
+                buildorder: 9

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,7 +27,7 @@ def test_debug_option(mock_config, tmpdir):
 
     Args = namedtuple("Args", ["modulemd", "mock_cfg", "debug", "workdir", "resume",
                                "module_name", "module_stream", "module_version",
-                               "add_repo", "rootdir", "module_context", "srpm_dir"])
+                               "add_repo", "rootdir", "module_context", "srpm_dir", "workers", "no_stdout"])
 
     args = Args(modulemd=full_path,
                 mock_cfg="/etc/mock/fedora-35-x86_64.cfg",
@@ -40,7 +40,9 @@ def test_debug_option(mock_config, tmpdir):
                 rootdir=None,
                 add_repo=[],
                 module_context=None,
-                srpm_dir=None)
+                srpm_dir=None,
+                workers=1,
+                no_stdout=False)
 
     with patch("module_build.cli.get_arg_parser") as mock_parser:
         mock_parser.return_value.parse_args.return_value = args
@@ -63,7 +65,7 @@ def test_reraise_exception(mock_config, tmpdir):
 
     Args = namedtuple("Args", ["modulemd", "mock_cfg", "debug", "workdir", "resume",
                                "module_name", "module_stream", "module_version",
-                               "add_repo", "rootdir", "module_context", "srpm_dir"])
+                               "add_repo", "rootdir", "module_context", "srpm_dir", "workers", "no_stdout"])
 
     args = Args(modulemd=full_path,
                 mock_cfg="/etc/mock/fedora-35-x86_64.cfg",
@@ -76,7 +78,9 @@ def test_reraise_exception(mock_config, tmpdir):
                 rootdir=None,
                 add_repo=[],
                 module_context=None,
-                srpm_dir=None)
+                srpm_dir=None,
+                workers=1,
+                no_stdout=False)
 
     with patch("module_build.cli.get_arg_parser") as mock_parser:
         mock_parser.return_value.parse_args.return_value = args
@@ -118,7 +122,7 @@ def test_choose_context_to_build(tmpdir):
 
     Args = namedtuple("Args", ["modulemd", "mock_cfg", "debug", "workdir", "resume",
                                "module_name", "module_stream", "module_version",
-                               "add_repo", "rootdir", "module_context", "srpm_dir"])
+                               "add_repo", "rootdir", "module_context", "srpm_dir", "workers", "no_stdout"])
 
     context_to_build = "f26devel"
 
@@ -133,7 +137,9 @@ def test_choose_context_to_build(tmpdir):
                 rootdir=None,
                 add_repo=[],
                 module_context=context_to_build,
-                srpm_dir=None)
+                srpm_dir=None,
+                workers=1,
+                no_stdout=False)
 
     with patch("module_build.cli.get_arg_parser") as mock_parser:
         mock_parser.return_value.parse_args.return_value = args


### PR DESCRIPTION
New CLI options:

- `--workers` - specify how many build processes spawn for batch build. Defaults to one for not multiprocess mode.
- `--no-stdout` - this is required for multiprocess mode. It self explanatory. Standard output printed to stdout would be very messy and not really readable due to weird order. Logger output is still printed to file.

Here is minimal stdout information in multiprocess mode:
![mock](https://user-images.githubusercontent.com/89029326/171390598-d6386215-1a10-4a5b-aaed-81de398d4e7a.png)

Pool with workers is spawn at the beginning of each batch. Some data are not properly utilized in this mode like `curr_comp_state` because of multi process communication. Those are not needed though.

Artifacts (list or built rpms) are transferred to main process via Proxylist which is slow because serialization/de-serialization but this should not cause delays in our scenario (should be avoided still though). Standard mode works in old way.

Queue is spawn per batch.

When component fails another component in batch in queue will continue building. Error will be thrown at the end of batch build.

TODO after check:
- tests
